### PR TITLE
Issues/96

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "format": "run-p format:js format:css",
     "format:js": "echo format:js",
     "format:css": "stylefmt -c .stylefmtrc -r src/css/**/*.pcss",
-    "format:css2": "stylefmt -v",
     "lint": "run-p lint:js lint:css",
     "lint:js": "eslint src",
     "lint:css": "stylelint src/css/**/*.pcss",


### PR DESCRIPTION
## content
stylefmtのバージョンが古いため、アップデートしたところ動作しました。

`5.3.2` -> `6.0.0`にアップデートしました。

## 6.0.0の変更内容

- Use yarn
- Upgrade dependencies
- Add support for *.less and *.pcss files in recursive cli mode.

recursiveCLIモードで*.pcssファイルをサポートしたようです。

### recursive とは
 -r, --recursive        Format list of space seperated files(globs) in place
