### PR TITLE
Issues/110

### DIFF
--- a/src/css/components/Tooltip.pcss
+++ b/src/css/components/Tooltip.pcss
@@ -71,7 +71,7 @@
 .Tooltip__text {
   position: relative;
   min-width: 30px;
-  padding: 10px;
+  padding: 5px 10px;
   color: var(--color-basic-white);
   background-color: var(--color-basic-darkGray);
   border-radius: 5px;


### PR DESCRIPTION
## [TooltipのLabelが半角１文字のとき、▼がずれて見える](https://github.com/cam-inc/dmc/issues/110)

## 原因

- 半角一文字の場合を想定していなかった。

## 対処

1. Tooltip__textへmin-widthを設定
1. padding値も足りないと思ったので対処。
1. 半角一文字を想定していなかった部分の数値変更。

## 対処後

### 半角一文字

<img width="221" alt="2017-08-21 11 52 55" src="https://user-images.githubusercontent.com/11499282/29502007-c6777afc-8667-11e7-9839-50c5d9097f99.png">

### 半角2文字以上

<img width="183" alt="2017-08-21 11 54 11" src="https://user-images.githubusercontent.com/11499282/29502017-d4df2b12-8667-11e7-8a9b-70e1e07769aa.png">
