### PR TITLE
Issues/104

### DIFF
--- a/src/css/components/Colorpicker.pcss
+++ b/src/css/components/Colorpicker.pcss
@@ -158,8 +158,8 @@
   @apply --layout-center-center:
   width: 100%;
   font-weight: 600;
-  text-align: center;
   color: var(--color-text-secondary);
+  text-align: center;
   cursor: default;
 }
 


### PR DESCRIPTION
## Content
カラーピッカーのエラーを修正しました。

## エラー内容
HEXを選択したとき、HEXをのラベルが左揃えになっていましたので、中央に直しました。

<img width="252" alt="ss 2017-09-06 10 34 07" src="https://user-images.githubusercontent.com/12236042/30091464-ab692aaa-92f4-11e7-8782-c79a17efa199.png">
