### PR TITLE
ダブルタップ問題改修

### DIFF
--- a/src/store/actions/modals.js
+++ b/src/store/actions/modals.js
@@ -2,6 +2,7 @@ import { constants as mutations } from '../mutations';
 
 // モーダルを多重起動しないよう判定する変数
 let canCreateModal = true;
+// タイマーID管理用変数
 let timer;
 
 export default {
@@ -15,15 +16,15 @@ export default {
    */
   add: (context, tagName, tagOpts, modalOpts) => {
     if (!canCreateModal) {
+      console.warn('多重に起動しないよう、一定時間のモーダル作成を規制する。'); // eslint-disable-line no-console
       return;
     }
 
     // モーダル作成を一時的に不可にする。
-    console.warn('多重に起動しないよう、一定時間のモーダル作成を規制する。'); // eslint-disable-line no-console
     canCreateModal = false;
     clearTimeout(timer);
 
-    // 一定時間後に作成可とする。
+    // 一定時間後にモーダル作成可とする。
     timer = setTimeout(() => {
       canCreateModal = true;
     }, 300);


### PR DESCRIPTION
## Content
同一内容のモーダルを一定時間起動しないよう修正しました。

## issue number
https://github.com/cam-inc/viron/issues/76

## How to
```js
// モーダルを多重起動しないよう判定する変数
let canCreateModal = true;

// ...

// モーダル作成を一時的に不可にする。
canCreateModal = false;

// 一定時間後に作成可とする。
setTimeout(() => {
  canCreateModal = true;
}, 300);
```