### PR TITLE
クリップボードへのコピーで失敗している箇所の修正

### DIFF
--- a/src/components/viron-numberinput/index.js
+++ b/src/components/viron-numberinput/index.js
@@ -8,7 +8,7 @@ import isUndefined from 'mout/lang/isUndefined';
 export default function() {
   const store = this.riotx.get();
 
-  // クリップっボードコピーをサポートしているか否か。
+  // クリップボードコピーをサポートしているか否か。
   let isClipboardCopySupported = true;
   // モバイル用レイアウトか否か。
   this.isMobile = store.getter('layout.isMobile');
@@ -114,7 +114,7 @@ export default function() {
     Promise
       .resolve()
       .then(() => {
-        return clipboard.copy(this.opts.val);
+        return clipboard.copy(String(this.opts.val));
       })
       .then(() => store.action('toasts.add', {
         message: 'クリップボードへコピーしました。'


### PR DESCRIPTION
## ISSUE
> クリップボードコピー、たまにバグる
https://github.com/cam-inc/viron/issues/206

## 改善

number型はコピーできないようなので、Stringにcast
以下エラー↓
> Invalid data type. Must be string, DOM node, or an object mapping MIME types to strings.