### PR TITLE
複数画像アップロードバグ対応

### DIFF
--- a/src/components/viron-uploader/index.js
+++ b/src/components/viron-uploader/index.js
@@ -1,5 +1,5 @@
 export default function() {
-  this.inputId = `Uploader__input_${this._riot_id}`;
+  this.inputId = `Uploader__input${this._riot_id}`;
   this.file = null;
   this.fileName = null;
   this.isTypeOfImage = false;


### PR DESCRIPTION
inputタグにセットするidが this.__riot_id となっていたため全てのinputタグのidが[Uploader__inputundefined]になっていた。
正しい値[Uploader__input_nnn]（のはず）になるよう修正。