### PR TITLE
カードのベースの枠色を変更

### DIFF
--- a/src/css/settings/theme.css
+++ b/src/css/settings/theme.css
@@ -41,7 +41,7 @@
   --theme-standard-header-bg: #f9f9f9;
   --theme-standard-orderButton-bg: #d1d1d1;
   --theme-standard-endpointCard-bg: #fff;
-  --theme-standard-endpointCard-border: #c6c6c5;
+  --theme-standard-endpointCard-border: #e4e4e2;
   --theme-standard-popover-bg: #fff;
   --theme-standard-tag-text: #d1d1d1;
   --theme-standard-tag-bg: #f9f9f9;


### PR DESCRIPTION
## ISSUE

https://github.com/cam-inc/viron/issues/283

##  OVERVIEW

カードのフチのベースカラーを変更 `#E4E4E2` に