### PR TITLE
カードの角丸値6pxに

### DIFF
--- a/src/css/pages/ComponentsPage_Card.css
+++ b/src/css/pages/ComponentsPage_Card.css
@@ -1,7 +1,8 @@
 .ComponentsPage_Card {
   display: block;
   width: 100%;
+  overflow: hidden;
   background-color: var(--theme-componentCard-bg);
   border: 1px solid var(--theme-componentCard-border);
-  border-radius: 4px;
+  border-radius: 6px;
 }


### PR DESCRIPTION
## ISSUE

https://github.com/cam-inc/viron/issues/284

## OVERVIEW

- カードの角丸を`6px`に変更
- 子ビューが飛び出ていたので、親に`overflow:hidden`を指定