### PR TITLE
左側のメニューの余白調整

### DIFF
--- a/src/css/components/Application_Menu.css
+++ b/src/css/components/Application_Menu.css
@@ -29,6 +29,7 @@
     @apply --layout-column-center-stretch;
     position: relative;
     height: 100%;
+    padding-top: 16px;
   }
 
   &__head {
@@ -36,7 +37,6 @@
     flex-shrink: 0;
     height: 64px;
     padding: 0 16px;
-    margin-top: 16px;
   }
 
   &__homeButton {

--- a/src/css/components/Application_Menu_Group.css
+++ b/src/css/components/Application_Menu_Group.css
@@ -34,10 +34,13 @@
   }
 
   &__page {
+    @apply --layout-center-start;
+
     @mixin hover {
       color: var(--color-base-blue);
     }
-    padding: 12px 12px 16px 32px;
+    height: 50px;
+    padding-left: 32px;
     font-size: 1.4rem;
     cursor: pointer;
   }


### PR DESCRIPTION
## ISSUE

https://github.com/cam-inc/viron/issues/288

## OVERVIEW

左側のメニューの余白調整

- トップに`margin-top`
- セルの`padding`調整
- 開いたアイテムの下部に `margin-bottom`

![2018-01-29 17 22 56](https://user-images.githubusercontent.com/3895795/35500729-cc3692ca-051a-11e8-9c4e-d60db86ad08f.png)
