### PR TITLE
テーブルcell操作用アイコンの背景グラデを調整

### DIFF
--- a/src/css/pages/ComponentsPage_Card_Table.css
+++ b/src/css/pages/ComponentsPage_Card_Table.css
@@ -120,8 +120,9 @@
       position: sticky;
       right: 0;
       width: 28px;
+      padding: 8px 24px 8px 32px;
       text-align: center;
-      background: linear-gradient(to right, var(--theme-componentCardTable-grad-start), 0%, var(--theme-componentCardTable-grad-end) 50%, var(--theme-componentCardTable-grad-end) 100%);
+      background: linear-gradient(to right, var(--theme-componentCardTable-grad-start) 0%, var(--theme-componentCardTable-grad-end) 20%, var(--theme-componentCardTable-grad-end) 100%);
     }
   }
 
@@ -146,14 +147,15 @@
       }
       width: 16px;
       height: 16px;
-      margin: 0 auto;
+      margin-right: 26px;
+      margin-left: auto;
       cursor: pointer;
     }
 
     &--sticky {
       position: sticky;
       right: 0;
-      background: linear-gradient(to right, var(--theme-componentCardTable-grad-start) 0%, var(--theme-componentCardTable-grad-end) 50%, var(--theme-componentCardTable-grad-end) 100%);
+      background: linear-gradient(to right, var(--theme-componentCardTable-grad-start) 0%, var(--theme-componentCardTable-grad-end) 20%, var(--theme-componentCardTable-grad-end) 100%);
     }
   }
 

--- a/src/css/pages/ComponentsPage_Card_Table.css
+++ b/src/css/pages/ComponentsPage_Card_Table.css
@@ -120,7 +120,7 @@
       position: sticky;
       right: 0;
       width: 28px;
-      padding: 8px 24px 8px 32px;
+      padding-left: 32px;
       text-align: center;
       background: linear-gradient(to right, var(--theme-componentCardTable-grad-start) 0%, var(--theme-componentCardTable-grad-end) 20%, var(--theme-componentCardTable-grad-end) 100%);
     }


### PR DESCRIPTION
## Issue

- #293

## Overview

- アイコンの背景グラデを調整

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3895795/35569065-5734ff4e-060e-11e8-81a9-5f5a0e3b17f6.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3895795/35569089-738f7c00-060e-11e8-971e-5e74512bf42b.png" width="300" />
