### PR TITLE
GET /viron/authtype

### DIFF
--- a/demo/swagger/swagger.yaml
+++ b/demo/swagger/swagger.yaml
@@ -1892,7 +1892,7 @@ paths:
       tags:
       - viron
 
-  /viron_authtype:
+  /viron/authtype:
     get:
       x-swagger-router-controller: viron_authtype
       description: 認証方式一覧

--- a/example-email/swagger/swagger.yaml
+++ b/example-email/swagger/swagger.yaml
@@ -966,7 +966,7 @@ paths:
       tags:
       - viron
 
-  /viron_authtype:
+  /viron/authtype:
     get:
       x-swagger-router-controller: viron_authtype
       description: 認証方式一覧

--- a/example-google/swagger/swagger.yaml
+++ b/example-google/swagger/swagger.yaml
@@ -955,7 +955,7 @@ paths:
       tags:
       - viron
 
-  /viron_authtype:
+  /viron/authtype:
     get:
       x-swagger-router-controller: viron_authtype
       description: 認証方式一覧

--- a/src/store/actions/auth.js
+++ b/src/store/actions/auth.js
@@ -89,7 +89,7 @@ export default exporter('auth', {
           .resolve()
           .then(() => fetch(context, oldFetchUrl))
           .then(response => {
-            console.warn('Deprecated: use [GET /viron/authtype] instead of [GET /viron_authtype].');
+            console.warn('Deprecated: use [GET /viron/authtype] instead of [GET /viron_authtype].');// eslint-disable-line no-console
             return response.json();
           });
       });


### PR DESCRIPTION
認証方法取得APIを、`GET /viron_authtype` -> `GET /viron/authtype`に変更する。

- [x] `GET /viron/authtype`にリクエスト投げる。ミスったら`GET /viron_authtype`にも投げる。
- [x] demo修正
- [x] ドキュメント修正

**リリース後に(こちら)[https://github.com/cam-inc/viron-doc/pull/17]をmerge&公開すること**