### PR TITLE
Disable duplicate post  on submit button

### DIFF
--- a/src/pages/viron-components/operation/index.js
+++ b/src/pages/viron-components/operation/index.js
@@ -72,6 +72,7 @@ export default function() {
   };
 
   const confirmSubmit = () => {
+    let isOperating = false;
     if (!this.isValid) {
       return;
     }
@@ -80,6 +81,8 @@ export default function() {
       message: '本当に実行しますか？',
       labelPositive: this.submitLabel,
       onPositiveSelect: () => {
+        if (isOperating) return;
+        isOperating = true;
         operate();
       }
     }));


### PR DESCRIPTION
## Issue
-

## Overview (Required)
submitボタン連打で同じ内容のpostが行われるため、confirmSubmit()内でフラグ管理を行いsubmit処理を複数行わないよう制御する

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
