### PR TITLE
Treat table cell as image if format is `image-url`

### DIFF
--- a/src/pages/viron-components/card/table/cell/index.js
+++ b/src/pages/viron-components/card/table/cell/index.js
@@ -58,6 +58,11 @@ export default function() {
         }
         return data;
       }
+      // formatがimage-urlであれば画像とする
+      if (column.format === 'image-url') {
+        this.isImage = true;
+        return data;
+      }
       // 拡張子から最適な表示方法を推測します。
       const split = data.split('.');
       if (split.length < 2) {


### PR DESCRIPTION
## Issue
- Image URLs are shown as text if they are not suffixed with one of the image extensions

## Overview (Required)
- Treat table cell as image if format is `image-url`

## Links
-

## Screenshot
Before | After
:--: | :--:
![viron](https://user-images.githubusercontent.com/28143/39080492-b4a3b9b8-456a-11e8-98f0-190b20c59298.png) | ![viron](https://user-images.githubusercontent.com/28143/39080498-c725c4c8-456a-11e8-915d-8a746e83df61.png)


