### PR TITLE
Fix bug of editor font size selection

### DIFF
--- a/src/components/viron-wyswyg/index.js
+++ b/src/components/viron-wyswyg/index.js
@@ -34,6 +34,7 @@ const menuDesktop = {
 const menuMobile = {};
 const baseConfig = {
   plugins: ['code', 'hr', 'lists', 'link', 'image', 'paste', 'searchreplace', 'fullscreen', 'table', 'textcolor'],
+  fontsize_formats: '8pt 10pt 11pt 12pt 14pt 18pt 24pt 36pt',
   min_height: 300,
   branding: false,
   relative_urls: false,


### PR DESCRIPTION
## Overview (Required)
- The default font size(11pt) can not be selected from the menu, so i added.

## Link
- https://www.tiny.cloud/docs/configure/content-formatting/#fontsize_formats

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3895795/45274221-60dcc800-b4f1-11e8-89bb-213900944d80.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3895795/45274227-6d612080-b4f1-11e8-97bc-a5ba87698843.png" width="300" />

