### PR TITLE
node_modules and .git are not required for build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules


### PR DESCRIPTION
## Issue
I happend wait for very longtime on docker build.
The cause I guess is content synchronization to the container.
Thanks.

## Overview (Required)
-

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
