### PR TITLE
`authtypes`  のパスを401のときのレスポンスヘッダで指定する

### DIFF
--- a/example/nodejs/src/application.ts
+++ b/example/nodejs/src/application.ts
@@ -10,6 +10,7 @@ export const createApplication = async (): Promise<Express> => {
 
   // Express configuration
   app.set('port', process.env.PORT || 3000);
+
   app.use(compression());
   app.use(json());
   app.use(urlencoded({ extended: true }));

--- a/example/nodejs/src/constant.ts
+++ b/example/nodejs/src/constant.ts
@@ -2,3 +2,5 @@ export const MODE_MYSQL = 'mysql';
 export const MODE_MONGO = 'mongo';
 export type Mode = typeof MODE_MYSQL | typeof MODE_MONGO;
 export type StoreType = Mode;
+
+export const VIRON_AUTHTYPES_PATH = '/viron_authtype';

--- a/example/nodejs/src/handlers/unauthorized.ts
+++ b/example/nodejs/src/handlers/unauthorized.ts
@@ -1,13 +1,18 @@
+import { constants } from '@viron/lib';
 import { NextFunction, Request, Response } from 'express';
 import { Context as RequestContext } from 'openapi-backend';
+import { VIRON_AUTHTYPES_PATH } from '../constant';
 import { unauthorized } from '../errors';
+
+const { HTTP_HEADER } = constants;
 
 // securityHandlerでエラーになったリクエストをハンドリング
 export const unauthorizedHandler = async (
   _context: RequestContext,
   _req: Request,
-  _res: Response,
+  res: Response,
   next: NextFunction
 ): Promise<void> => {
+  res.set(HTTP_HEADER.X_VIRON_AUTHTYPES_PATH, VIRON_AUTHTYPES_PATH);
   next(unauthorized());
 };

--- a/example/nodejs/src/routes/index.ts
+++ b/example/nodejs/src/routes/index.ts
@@ -58,15 +58,17 @@ export async function register(app: Express): Promise<void> {
   apis.forEach((api) => {
     apiDefinition = merge(apiDefinition, api.definition);
     // add handler
-    app.use((req, res, next) =>
-      api.handleRequest(
-        req as OpenapiRequest,
-        req,
-        res,
-        next,
-        apiDefinition as Document
-      )
-    );
+    app.use((req, res, next) => {
+      api
+        .handleRequest(
+          req as OpenapiRequest,
+          req,
+          res,
+          next,
+          apiDefinition as Document
+        )
+        .catch(next);
+    });
     // logging
     api.router.getOperations().forEach((operation: Operation) => {
       logger.debug(

--- a/packages/nodejs/src/constants.ts
+++ b/packages/nodejs/src/constants.ts
@@ -70,3 +70,8 @@ export const STORE_TYPE = {
   MONGO: 'mongo',
 } as const;
 export type StoreType = typeof STORE_TYPE[keyof typeof STORE_TYPE];
+
+export const HTTP_HEADER = {
+  X_VIRON_AUTHTYPES_PATH: 'X-Viron-Authtypes-Path',
+} as const;
+export type HttpHeader = typeof HTTP_HEADER[keyof typeof HTTP_HEADER];


### PR DESCRIPTION
## Issue
- `/viron_authtypes` をサーバ側から指定する

## Overview (Required)
- `401: unauthorized` を返すときのレスポンスヘッダに `authtypes` のパスを返すようにした

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
