### PR TITLE
Refactor: rename swagger to oas, unique operationId

### DIFF
--- a/example/nodejs/src/openapi/ping.yaml
+++ b/example/nodejs/src/openapi/ping.yaml
@@ -10,7 +10,7 @@ tags:
 paths:
   /ping:
     get:
-      operationId: get
+      operationId: getPing
       tags:
         - ping
       summary: ping

--- a/example/nodejs/src/openapi/root.yaml
+++ b/example/nodejs/src/openapi/root.yaml
@@ -13,11 +13,11 @@ tags:
 paths:
   /:
     get:
-      operationId: get
+      operationId: getRoot
       tags:
         - root
-      summary: redirect to /swagger.json
-      description: /swagger.jsonへリダイレクト
+      summary: redirect to /oas
+      description: /oas へリダイレクト
       responses:
         301:
           description: OK

--- a/example/nodejs/src/routes/auditlogs.ts
+++ b/example/nodejs/src/routes/auditlogs.ts
@@ -6,7 +6,7 @@ import { Context as RequestContext } from 'openapi-backend';
  * 監査ログ一覧
  * @route GET /auditlogs
  */
-export const list = async (
+export const listAuditlogs = async (
   _context: RequestContext,
   _req: Request,
   res: Response

--- a/example/nodejs/src/routes/authtypes.ts
+++ b/example/nodejs/src/routes/authtypes.ts
@@ -9,7 +9,7 @@ const { genAuthType } = domains.authType;
  * 認証タイプ一覧
  * @route GET /viron_authtype
  */
-export const list = async (
+export const listAuthtypes = async (
   _context: RequestContext,
   _req: Request,
   res: Response

--- a/example/nodejs/src/routes/index.ts
+++ b/example/nodejs/src/routes/index.ts
@@ -20,7 +20,7 @@ import * as routesAuditLogs from './auditlogs';
 import * as routesAuthtypes from './authtypes';
 import * as routesPing from './ping';
 import * as routesRoot from './root';
-import * as routesSwagger from './swagger';
+import * as routesOas from './oas';
 import * as routesViron from './viron';
 
 interface Route {
@@ -31,7 +31,7 @@ interface Route {
 const routes: Route[] = [
   { openapiPath: openapiPath('ping'), handlers: routesPing },
   { openapiPath: libOpenapiPath('auditlogs'), handlers: routesAuditLogs },
-  { openapiPath: libOpenapiPath('swagger'), handlers: routesSwagger },
+  { openapiPath: libOpenapiPath('oas'), handlers: routesOas },
   { openapiPath: libOpenapiPath('viron'), handlers: routesViron },
   { openapiPath: libOpenapiPath('authtypes'), handlers: routesAuthtypes },
   // マージ順の関係で`root`は必ず最後に書く

--- a/example/nodejs/src/routes/oas.ts
+++ b/example/nodejs/src/routes/oas.ts
@@ -2,10 +2,10 @@ import { Response, Request, NextFunction } from 'express';
 import { Context as RequestContext, Document } from 'openapi-backend';
 
 /**
- * swagger.json
- * @route GET /swagger.json
+ * oas取得
+ * @route GET /oas
  */
-export const get = async (
+export const getOas = async (
   _context: RequestContext,
   _req: Request,
   res: Response,

--- a/example/nodejs/src/routes/ping.ts
+++ b/example/nodejs/src/routes/ping.ts
@@ -9,7 +9,7 @@ const repositoryContainer = repositories.container;
  * Ping
  * @route GET /ping
  */
-export const get = async (
+export const getPing = async (
   _context: RequestContext,
   _req: Request,
   res: Response

--- a/example/nodejs/src/routes/root.ts
+++ b/example/nodejs/src/routes/root.ts
@@ -5,10 +5,10 @@ import { Context as RequestContext } from 'openapi-backend';
  * root
  * @route GET /
  */
-export const get = async (
+export const getRoot = async (
   _context: RequestContext,
   _req: Request,
   res: Response
 ): Promise<void> => {
-  res.redirect(301, '/swagger.json');
+  res.redirect(301, '/oas');
 };

--- a/example/nodejs/src/routes/viron.ts
+++ b/example/nodejs/src/routes/viron.ts
@@ -16,7 +16,7 @@ const {
  * viron全体設定を取得
  * @route GET /viron
  */
-export const get = async (
+export const getViron = async (
   _context: RequestContext,
   req: Request,
   res: Response

--- a/packages/nodejs/src/openapi/auditlogs.yaml
+++ b/packages/nodejs/src/openapi/auditlogs.yaml
@@ -10,7 +10,7 @@ tags:
 paths:
   /auditlogs:
     get:
-      operationId: list
+      operationId: listAuditlogs
       tags:
         - auditLog
       summary: list audit logs

--- a/packages/nodejs/src/openapi/authtypes.yaml
+++ b/packages/nodejs/src/openapi/authtypes.yaml
@@ -10,7 +10,7 @@ tags:
 paths:
   /viron_authtype:
     get:
-      operationId: list
+      operationId: listAuthtypes
       tags:
         - authType
       summary: list auth types

--- a/packages/nodejs/src/openapi/oas.yaml
+++ b/packages/nodejs/src/openapi/oas.yaml
@@ -1,20 +1,20 @@
 openapi: 3.0.2
 info:
   version: 0.0.1
-  title: '@viron/example-nodejs swagger.json'
-  description: swagger.json api specifications
+  title: '@viron/example-nodejs oas'
+  description: oas api specifications
 
 tags:
-  - name: swagger
+  - name: oas
 
 paths:
-  /swagger.json:
+  /oas:
     get:
-      operationId: get
+      operationId: getOas
       tags:
-        - swagger
-      summary: get swagger.json
-      description: swagger.jsonの取得
+        - oas
+      summary: get oas
+      description: OpenAPI Specification の取得
       responses:
         '200':
           description: OK

--- a/packages/nodejs/src/openapi/viron.yaml
+++ b/packages/nodejs/src/openapi/viron.yaml
@@ -10,7 +10,7 @@ tags:
 paths:
   /viron:
     get:
-      operationId: get
+      operationId: getViron
       tags:
         - viron
       summary: get viron settings


### PR DESCRIPTION
## Issue
- `swagger` => `oas` に統一
- `operationId` を全体でユニークになるように調整

## Overview (Required)
-

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
