### PR TITLE
Update portal a11y

### DIFF
--- a/packages/app/src/components/popover/index.tsx
+++ b/packages/app/src/components/popover/index.tsx
@@ -75,6 +75,23 @@ const PopoverLg: React.FC<Props> = ({
     },
     [targetRef, onRequestClose]
   );
+
+  useEffect(
+    function () {
+      const cleanup = function () {
+        window.removeEventListener('keydown', handler);
+      };
+      const handler = function (e: KeyboardEvent) {
+        if (e.key === 'Escape') {
+          onRequestClose();
+        }
+      };
+      window.addEventListener('keydown', handler);
+      return cleanup;
+    },
+    [onRequestClose]
+  );
+
   useEffect(
     function () {
       onRequestClose();
@@ -341,6 +358,22 @@ const PopoverNotLg: React.FC<Props> = ({
       setIsVisible(isOpened);
     },
     [isOpened]
+  );
+
+  useEffect(
+    function () {
+      const cleanup = function () {
+        window.removeEventListener('keydown', handler);
+      };
+      const handler = function (e: KeyboardEvent) {
+        if (e.key === 'Escape') {
+          onRequestClose();
+        }
+      };
+      window.addEventListener('keydown', handler);
+      return cleanup;
+    },
+    [onRequestClose]
   );
 
   const handleBGClick = useCallback(

--- a/packages/app/src/components/popover/index.tsx
+++ b/packages/app/src/components/popover/index.tsx
@@ -196,7 +196,7 @@ const PopoverLg: React.FC<Props> = ({
     function () {
       const space = 8;
       const commonClassName =
-        'p-2 rounded bg-surface-05dp shadow-05dp overflow-scroll overscroll-contain';
+        'p-2 rounded bg-surface-05dp shadow-05dp overflow-auto overscroll-contain';
       switch (placement) {
         case PLACEMENT.TOP_LEFT: {
           return (


### PR DESCRIPTION
## Issue
-

## Overview (Required)
- `Portal`を使ったコンポーネント(合計5つ)のa11y改善
- `Popover`
  - `esc`キーを押した時にポップオーバーが閉じる
  - 不要なパディングを削除するため`overflow-scroll`→`overflow-auto`に変更

## Links
-

## Screenshot
Before | After
:--: | :--:

