### PR TITLE
🐛Fix：components.schema.propertiesのrefが置換されない

### DIFF
--- a/packages/golang/helpers/oas.go
+++ b/packages/golang/helpers/oas.go
@@ -133,6 +133,9 @@ func Ref(docRoot *openapi3.T, org string, rep string) error {
 			for _, any := range schema.Value.AnyOf {
 				any.Ref = ref(any.Ref, org, rep)
 			}
+			for _, property := range schema.Value.Properties {
+				property.Ref = ref(property.Ref, org, rep)
+			}
 		}
 	}
 	for _, response := range docRoot.Components.Responses {


### PR DESCRIPTION
## Issue
- vrionのfrontにoas返却する際に ./components.yamlなど別ファイルrefの記述になってしまう。

## fixes
- schemaのpropertiesも置換するようにした。
