### PR TITLE
[fix]数値入力項に小数を入力すると、小数点が消える不具合の修正

### DIFF
--- a/src/components/viron-numberinput/index.js
+++ b/src/components/viron-numberinput/index.js
@@ -5,7 +5,7 @@ import _isNumber from 'mout/lang/isNumber';
 import isString from 'mout/lang/isString';
 import isUndefined from 'mout/lang/isUndefined';
 
-export default function() {
+export default function () {
   const store = this.riotx.get();
 
   // クリップボードコピーをサポートしているか否か。
@@ -44,7 +44,7 @@ export default function() {
     // 文字列を受け取った場合は形式によって返却値が変わる。
     if (isString(value)) {
       // 数字と`-`と`.`のみも文字列に変換する。
-      value = value.replace(/[^-^0-9]/g, '');
+      value = value.replace(/[^-.^0-9]/g, '');
       // 空文字列の場合はnullとして扱う。
       if (!value.length) {
         return null;


### PR DESCRIPTION
Swaggerファイルで”type: number/format: float”にて定義した入力項へ小数を入力すると、
小数点が置換されて消える現象を確認しました。


以下方法であれば現在でも小数点は入力可能です(ただし保存時に小数点は消えます)
・全部の桁数を入れる　(ex:   123456)
・最後に任意箇所に小数点入れる (ex:  123.456)
