### PR TITLE
🐛Fix：jwt iss aud injection verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ tsconfig.tsbuildinfo
 !.gitkeep
 
 .env
+
+.idea

--- a/example/golang/routes/middleware.go
+++ b/example/golang/routes/middleware.go
@@ -204,7 +204,7 @@ func JWTAuthHandlerFunc() func(http.HandlerFunc) http.HandlerFunc {
 				return
 			}
 			fmt.Println("DEBUG1")
-			claim, err := auth.Verify(token)
+			claim, err := auth.Verify(r, token)
 			if err != nil {
 				fmt.Println(err)
 				handlerFunc.ServeHTTP(w, r.WithContext(ctx))
@@ -240,7 +240,7 @@ func JWTSecurityHandlerFunc(cfg *config.Auth) func(http.HandlerFunc) http.Handle
 				http.Error(w, errors.UnAuthorized.Error(), errors.UnAuthorized.StatusCode())
 				return
 			}
-			claim, err := auth.Verify(token)
+			claim, err := auth.Verify(r, token)
 			if err != nil {
 				fmt.Println(err)
 				w.Header().Add(constant.HTTP_HEADER_X_VIRON_AUTHTYPES_PATH, constant.VIRON_AUTHCONFIGS_PATH)
@@ -305,7 +305,7 @@ func InjectAuditLog(next http.Handler) http.Handler {
 			}
 
 			if token, err := helpers.GetCookieToken(r); err == nil {
-				if claim, err := auth.Verify(token); err == nil && claim != nil {
+				if claim, err := auth.Verify(r, token); err == nil && claim != nil {
 					userID = claim.Sub
 				}
 			}

--- a/example/golang/routes/routes.go
+++ b/example/golang/routes/routes.go
@@ -155,12 +155,12 @@ func New() http.Handler {
 		BaseRouter: routeRoot,
 		Middlewares: []oas.MiddlewareFunc{
 			InjectAPIDefinition(definition),
-			InjectAPIACL(definition),
 			JWTAuthHandlerFunc(),
 			OpenAPI3ValidatorHandlerFunc(definition, &openapi3filter.Options{
 				AuthenticationFunc: AuthenticationFunc,
 			}),
 			JWTSecurityHandlerFunc(cfg.Auth),
+			InjectAPIACL(definition),
 		},
 	})
 
@@ -169,12 +169,12 @@ func New() http.Handler {
 		BaseRouter: routeRoot,
 		Middlewares: []adminusers.MiddlewareFunc{
 			InjectAPIDefinition(definition),
-			InjectAPIACL(definition),
 			JWTSecurityHandlerFunc(cfg.Auth),
 			OpenAPI3ValidatorHandlerFunc(definition, &openapi3filter.Options{
 				AuthenticationFunc: AuthenticationFunc,
 			}),
 			JWTSecurityHandlerFunc(cfg.Auth),
+			InjectAPIACL(definition),
 		},
 	})
 
@@ -183,12 +183,12 @@ func New() http.Handler {
 		BaseRouter: routeRoot,
 		Middlewares: []adminaccounts.MiddlewareFunc{
 			InjectAPIDefinition(definition),
-			InjectAPIACL(definition),
 			JWTSecurityHandlerFunc(cfg.Auth),
 			OpenAPI3ValidatorHandlerFunc(definition, &openapi3filter.Options{
 				AuthenticationFunc: AuthenticationFunc,
 			}),
 			JWTSecurityHandlerFunc(cfg.Auth),
+			InjectAPIACL(definition),
 		},
 	})
 
@@ -197,12 +197,12 @@ func New() http.Handler {
 		BaseRouter: routeRoot,
 		Middlewares: []adminroles.MiddlewareFunc{
 			InjectAPIDefinition(definition),
-			InjectAPIACL(definition),
 			JWTSecurityHandlerFunc(cfg.Auth),
 			OpenAPI3ValidatorHandlerFunc(definition, &openapi3filter.Options{
 				AuthenticationFunc: AuthenticationFunc,
 			}),
 			JWTSecurityHandlerFunc(cfg.Auth),
+			InjectAPIACL(definition),
 		},
 	})
 
@@ -226,8 +226,8 @@ func New() http.Handler {
 		BaseRouter: routeRoot,
 		Middlewares: []auditlogs.MiddlewareFunc{
 			InjectAPIDefinition(definition),
-			InjectAPIACL(definition),
 			JWTSecurityHandlerFunc(cfg.Auth),
+			InjectAPIACL(definition),
 		},
 	})
 

--- a/packages/golang/domains/auth/googleauth.go
+++ b/packages/golang/domains/auth/googleauth.go
@@ -109,7 +109,7 @@ func SigninGoogleOAuth2(code string, redirectUrl string, r *http.Request) (strin
 		return "", errors.SigninFailed
 	}
 
-	token, err := Sign(user.ID)
+	token, err := Sign(r, user.ID)
 	if err != nil {
 		log.Error("SigninGoogleOAuth2 sign failed %#v \n", err)
 		return "", errors.SigninFailed

--- a/packages/golang/domains/auth/jwt_test.go
+++ b/packages/golang/domains/auth/jwt_test.go
@@ -11,6 +11,7 @@ import (
 const (
 	secret   = "xxxxxx"
 	provider = "test"
+	clientID = "testClientId"
 )
 
 func init() {
@@ -19,7 +20,7 @@ func init() {
 }
 
 func getProvider(r *http.Request) (string, []string, error) {
-	return provider, []string{provider}, nil
+	return provider, []string{clientID}, nil
 }
 
 func TestAuthJWTSignNormal(t *testing.T) {
@@ -30,11 +31,11 @@ func TestAuthJWTSignNormal(t *testing.T) {
 	fmt.Println(err)
 	fmt.Println(token)
 	sepToken := strings.Split(token, " ")[1]
-	claim, err := Verify(sepToken)
+	claim, err := Verify(r, sepToken)
 	fmt.Println(err)
 	fmt.Printf("claim=%v\n", claim)
 	time.Sleep(10 * time.Second)
-	claim2, err := Verify(sepToken)
+	claim2, err := Verify(r, sepToken)
 	fmt.Println(err)
 	fmt.Printf("claim2=%v\n", claim2)
 }


### PR DESCRIPTION
- verifyのhttp.Requestのinjectionが必要
- verifyでiss audは自分でチェックしないとchiのjwtauth.VerifyTokenではチェックしない
- exampleでACLAllowのcheckタイミングをadminuser.authの後にしないとadminuserが取れない