### PR TITLE
🐛Fix：add x-viron-authtypes-path to oasapi response header

### DIFF
--- a/packages/golang/routes/oas/oas.go
+++ b/packages/golang/routes/oas/oas.go
@@ -42,7 +42,7 @@ func (o *oas) GetOas(w http.ResponseWriter, r *http.Request) {
 		helpers.SendError(w, e.StatusCode(), e)
 		return
 	}
-
+	w.Header().Add(constant.HTTP_HEADER_X_VIRON_AUTHTYPES_PATH, constant.VIRON_AUTHCONFIGS_PATH)
 	helpers.Send(w, http.StatusOK, clone)
 }
 


### PR DESCRIPTION
## 内容
- oasApiのレスポンスヘッダーに`x-viron-authtypes-path` を追加

## なぜ
- vironのトップ画面から各oasを取得する際にこける
```
Endpoint Error
[#endpoint]
The x-viron-authtypes-path response header is missing.
```

## 補足
- node側の対応 https://github.com/cam-inc/viron/pull/528/files