### PR TITLE
🐛Fix:ロールが複数の場合リストテーブルが２つ表示される

### DIFF
--- a/packages/golang/domains/oas.go
+++ b/packages/golang/domains/oas.go
@@ -97,6 +97,7 @@ func GetOas(apiDef *openapi3.T, roleIDs []string) *openapi3.T {
 			rewritedPages = append(rewritedPages, page)
 		}
 	}
+	
 	log.Debugf("rewritedPages %+v", rewritedPages)
 
 	clone.Info.Extensions[constant.OAS_X_PAGES] = rewritedPages

--- a/packages/golang/domains/oas.go
+++ b/packages/golang/domains/oas.go
@@ -96,11 +96,6 @@ func GetOas(apiDef *openapi3.T, roleIDs []string) *openapi3.T {
 			page.Contents = granted
 			rewritedPages = append(rewritedPages, page)
 		}
-		fmt.Println("============================")
-		fmt.Printf("%+v \n", page.Group)
-		for _, content := range page.Contents {
-			fmt.Printf("%+v \n", content)
-		}
 	}
 
 	clone.Info.Extensions[constant.OAS_X_PAGES] = rewritedPages

--- a/packages/golang/domains/oas.go
+++ b/packages/golang/domains/oas.go
@@ -97,6 +97,7 @@ func GetOas(apiDef *openapi3.T, roleIDs []string) *openapi3.T {
 			rewritedPages = append(rewritedPages, page)
 		}
 	}
+	log.Debugf("rewritedPages %+v", rewritedPages)
 
 	clone.Info.Extensions[constant.OAS_X_PAGES] = rewritedPages
 	return clone

--- a/packages/golang/domains/oas.go
+++ b/packages/golang/domains/oas.go
@@ -85,6 +85,7 @@ func GetOas(apiDef *openapi3.T, roleIDs []string) *openapi3.T {
 				log.Debugf("roleId %s resourceId %s method2Permissions(pathMethod.method) %+v", roleID, content.ResourceID, method2Permissions(pathMethod.method))
 				if hasPermissionByResourceID(roleID, content.ResourceID, method2Permissions(pathMethod.method)) {
 					granted = append(granted, content)
+					break
 				}
 			}
 
@@ -95,9 +96,12 @@ func GetOas(apiDef *openapi3.T, roleIDs []string) *openapi3.T {
 			page.Contents = granted
 			rewritedPages = append(rewritedPages, page)
 		}
+		fmt.Println("============================")
+		fmt.Printf("%+v \n", page.Group)
+		for _, content := range page.Contents {
+			fmt.Printf("%+v \n", content)
+		}
 	}
-
-	log.Debugf("rewritedPages %+v", rewritedPages)
 
 	clone.Info.Extensions[constant.OAS_X_PAGES] = rewritedPages
 	return clone


### PR DESCRIPTION
## 概要
複数ロールが付与されたユーザーの場合に一覧画面で同じテーブルビューが２つ表示されてしまう
![image](https://user-images.githubusercontent.com/24517668/211720928-887326c3-0630-4e60-891f-b28e4e73b840.png)

## 変更内容
oas返却APIで複数ロール分ループでpages.ContentsのパーミッションチェックしてOKならbreakするようにして
2つContentができないようにした