### PR TITLE
skip husky install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "version": "2.0.2",
-      "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "packages/app",
@@ -19,7 +18,7 @@
         "@changesets/cli": "^2.20.0",
         "@commitlint/cli": "^16.1.0",
         "@commitlint/config-conventional": "^16.0.0",
-        "husky": "^5.0.6",
+        "husky": "^8.0.3",
         "pinst": "^2.1.1"
       },
       "engines": {
@@ -29387,25 +29386,18 @@
       }
     },
     "node_modules/husky": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-5.2.0.tgz",
-      "integrity": "sha512-AM8T/auHXRBxlrfPVLKP6jt49GCM2Zz47m8G3FOMsLmTv8Dj/fKVWE0Rh2d4Qrvmy131xEsdQnb3OXRib67PGg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/typicode"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/husky"
-        }
-      ],
       "bin": {
         "husky": "lib/bin.js"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/i18next": {
@@ -74704,9 +74696,9 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
     "husky": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-5.2.0.tgz",
-      "integrity": "sha512-AM8T/auHXRBxlrfPVLKP6jt49GCM2Zz47m8G3FOMsLmTv8Dj/fKVWE0Rh2d4Qrvmy131xEsdQnb3OXRib67PGg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
     },
     "i18next": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
         "@changesets/cli": "^2.20.0",
         "@commitlint/cli": "^16.1.0",
         "@commitlint/config-conventional": "^16.0.0",
-        "husky": "^8.0.3",
-        "pinst": "^2.1.1"
+        "husky": "^8.0.3"
       },
       "engines": {
         "node": ">=18.14.0",
@@ -25911,26 +25910,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -38096,21 +38075,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
       "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
-    },
-    "node_modules/pinst": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
-      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
-      "dev": true,
-      "dependencies": {
-        "fromentries": "^1.3.2"
-      },
-      "bin": {
-        "pinst": "bin.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/pirates": {
       "version": "4.0.5",
@@ -72152,12 +72116,6 @@
         }
       }
     },
-    "fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
-    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -81286,15 +81244,6 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.1.0.tgz",
       "integrity": "sha512-KO0m2f1HkrPe9S0ldjx7za9BJjeHqBku5Ch8JyxETxT8dEFGz1PwgrHaOQupVYitpzbFSYm7nnljxD8dik2c+g==",
       "dev": true
-    },
-    "pinst": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
-      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
-      "dev": true,
-      "requires": {
-        "fromentries": "^1.3.2"
-      }
     },
     "pirates": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/cam-inc/viron#readme",
   "scripts": {
-    "postinstall": "husky install",
+    "postinstall": "which husky && husky install || echo skip.",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable",
     "pre-commit": "npm run pre-commit --workspaces",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/cam-inc/viron#readme",
   "scripts": {
-    "postinstall": "which husky && husky install || echo skip.",
+    "prepare": "which husky && husky install || echo skip.",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable",
     "pre-commit": "npm run pre-commit --workspaces",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@changesets/cli": "^2.20.0",
     "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",
-    "husky": "^5.0.6",
+    "husky": "^8.0.3",
     "pinst": "^2.1.1"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
   "homepage": "https://github.com/cam-inc/viron#readme",
   "scripts": {
     "prepare": "which husky && husky install || echo skip.",
-    "prepublishOnly": "pinst --disable",
-    "postpublish": "pinst --enable",
     "pre-commit": "npm run pre-commit --workspaces",
     "pre-push": "npm run pre-push --workspaces",
     "changelog:intent": "changeset add",
@@ -50,8 +48,7 @@
     "@changesets/cli": "^2.20.0",
     "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",
-    "husky": "^8.0.3",
-    "pinst": "^2.1.1"
+    "husky": "^8.0.3"
   },
   "workspaces": [
     "packages/app",


### PR DESCRIPTION
## Summary
- bump husky version to v8
- skip husky install
-  remove pinst
    - Viron use npm and changed from postinstall to prepare
    - https://github.com/typicode/pinst

## Checklist
- [ ] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
