### PR TITLE
fix: build flow

### DIFF
--- a/codepipeline/app-buildspec.yml
+++ b/codepipeline/app-buildspec.yml
@@ -9,14 +9,14 @@ phases:
   pre_build:
     commands:
       - echo Install packages...
-      - cd $CODEBUILD_SRC_DIR/packages/app
-      - npm install --no-progress --legacy-peer-deps && npm cache verify
+      - cd $CODEBUILD_SRC_DIR
+      - npm install --no-progress
 
   build:
     commands:
-      - echo Building app...
-      - cd $CODEBUILD_SRC_DIR/packages/app
-      - npm run build
+      - echo Building linter & app...
+      - cd $CODEBUILD_SRC_DIR
+      - npm run build -w packages/linter -w packages/app
 
 artifacts:
   files:

--- a/codepipeline/app-buildspec.yml
+++ b/codepipeline/app-buildspec.yml
@@ -9,14 +9,18 @@ phases:
   pre_build:
     commands:
       - echo Install packages...
+      - cd $CODEBUILD_SRC_DIR/packages/linter
       - npm install --no-progress
       - echo Building linter...
-      - npm run build -w packages/linter
+      - npm run build
 
   build:
     commands:
+      - echo Install packages...
+      - cd $CODEBUILD_SRC_DIR/packages/app
+      - npm install --no-progress
       - echo Building app...
-      - npm run build -w packages/app
+      - npm run build
 
 artifacts:
   files:

--- a/codepipeline/app-buildspec.yml
+++ b/codepipeline/app-buildspec.yml
@@ -9,14 +9,14 @@ phases:
   pre_build:
     commands:
       - echo Install packages...
-      - cd $CODEBUILD_SRC_DIR
       - npm install --no-progress
+      - echo Building linter...
+      - npm run build -w packages/linter
 
   build:
     commands:
-      - echo Building linter & app...
-      - cd $CODEBUILD_SRC_DIR
-      - npm run build -w packages/linter -w packages/app
+      - echo Building app...
+      - npm run build -w packages/app
 
 artifacts:
   files:

--- a/codepipeline/snapshot-app-buildspec.yml
+++ b/codepipeline/snapshot-app-buildspec.yml
@@ -9,14 +9,15 @@ phases:
   pre_build:
     commands:
       - echo Install packages...
-      - cd $CODEBUILD_SRC_DIR/packages/app
-      - npm install --no-progress --legacy-peer-deps && npm cache verify
+      - npm install --no-progress
 
   build:
     commands:
+      - echo Building linter...
+      - npm run build -w packages/linter -w packages/app
       - echo Building app...
-      - cd $CODEBUILD_SRC_DIR/packages/app
-      - npm run build:prefix
+      - npm run build:prefix -w packages/app
+
 
 artifacts:
   files:

--- a/codepipeline/snapshot-app-buildspec.yml
+++ b/codepipeline/snapshot-app-buildspec.yml
@@ -10,11 +10,11 @@ phases:
     commands:
       - echo Install packages...
       - npm install --no-progress
+      - echo Building linter...
+      - npm run build -w packages/linter
 
   build:
     commands:
-      - echo Building linter...
-      - npm run build -w packages/linter -w packages/app
       - echo Building app...
       - npm run build:prefix -w packages/app
 

--- a/codepipeline/snapshot-app-buildspec.yml
+++ b/codepipeline/snapshot-app-buildspec.yml
@@ -9,14 +9,18 @@ phases:
   pre_build:
     commands:
       - echo Install packages...
+      - cd $CODEBUILD_SRC_DIR/packages/linter
       - npm install --no-progress
       - echo Building linter...
-      - npm run build -w packages/linter
+      - npm run build
 
   build:
     commands:
+      - echo Install packages...
+      - cd $CODEBUILD_SRC_DIR/packages/app
+      - npm install --no-progress
       - echo Building app...
-      - npm run build:prefix -w packages/app
+      - npm run build:prefix
 
 
 artifacts:


### PR DESCRIPTION
## Summary

An error occurred when building with develop.
```
failed Building production JavaScript and CSS bundles - 48.115s
error Generating JavaScript bundles failed

Can't resolve '@viron/linter' in '/codebuild/output/src017160690/src/codestar-connections.ap-northeast-1.amazonaws.com/git-http/394319427766/ap-northeast-1/c6e371fb-3561-4734-bfff-5db5eae4f396/cam-inc/viron/packages/app/src/utils/oas'

If you're trying to use a package make sure that '@viron/linter' is installed. If you're trying to use a local file make sure that the path is correct.
```

I have confirmed that the build was successful on my PC by following the same procedure as with this modification.

## Checklist
- [ ] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
