### PR TITLE
Resolving Conflicting Peer Dependencies

### DIFF
--- a/codepipeline/app-deployspec.yml
+++ b/codepipeline/app-deployspec.yml
@@ -23,7 +23,7 @@ phases:
       - aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_APP_DISTRIBUTION_ID --paths "/*"
       - echo E2E Testing...
       - cd $CODEBUILD_SRC_DIR/packages/app
-      - npm install --no-progress
+      - npm install --no-progress --legacy-peer-deps
       - |
         if [ "x${CYPRESS_BASE_URL}" != "x" ]; then
           npm run test:e2e:record

--- a/package-lock.json
+++ b/package-lock.json
@@ -49027,7 +49027,7 @@
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^13.4.0",
         "@types/classnames": "^2.2.11",
-        "@types/jest": "^26.0.24",
+        "@types/jest": "^27.4.0",
         "@types/markdown-it": "^12.2.1",
         "@types/qrcode": "^1.4.0",
         "@types/react-dom": "^18.0.10",
@@ -49055,41 +49055,6 @@
       "engines": {
         "node": ">=18.14.0",
         "npm": ">=9.3.1"
-      }
-    },
-    "packages/app/node_modules/@jest/types": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "packages/app/node_modules/@types/jest": {
-      "version": "26.0.24",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
-      "dev": true,
-      "dependencies": {
-        "jest-diff": "^26.0.0",
-        "pretty-format": "^26.0.0"
-      }
-    },
-    "packages/app/node_modules/@types/yargs": {
-      "version": "15.0.15",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.15.tgz",
-      "integrity": "sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "packages/app/node_modules/@typescript-eslint/eslint-plugin": {
@@ -49290,15 +49255,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "packages/app/node_modules/diff-sequences": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
     "packages/app/node_modules/eslint-plugin-prettier": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
@@ -49393,30 +49349,6 @@
         "@babel/runtime": "^7.12.0"
       }
     },
-    "packages/app/node_modules/jest-diff": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^26.6.2",
-        "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.6.2"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "packages/app/node_modules/jest-get-type": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
     "packages/app/node_modules/lint-staged": {
       "version": "10.5.4",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.5.4.tgz",
@@ -49445,27 +49377,6 @@
       "funding": {
         "url": "https://opencollective.com/lint-staged"
       }
-    },
-    "packages/app/node_modules/pretty-format": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/app/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
     },
     "packages/app/node_modules/semver": {
       "version": "7.3.8",
@@ -62373,7 +62284,7 @@
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^13.4.0",
         "@types/classnames": "^2.2.11",
-        "@types/jest": "^26.0.24",
+        "@types/jest": "^27.4.0",
         "@types/markdown-it": "^12.2.1",
         "@types/qrcode": "^1.4.0",
         "@types/react-dom": "^18.0.10",
@@ -62436,38 +62347,6 @@
         "yup": "^0.32.9"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/jest": {
-          "version": "26.0.24",
-          "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-          "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
-          "dev": true,
-          "requires": {
-            "jest-diff": "^26.0.0",
-            "pretty-format": "^26.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.15",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.15.tgz",
-          "integrity": "sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
         "@typescript-eslint/eslint-plugin": {
           "version": "4.33.0",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
@@ -62581,12 +62460,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "diff-sequences": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-          "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
-          "dev": true
-        },
         "eslint-plugin-prettier": {
           "version": "3.4.1",
           "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
@@ -62648,24 +62521,6 @@
             "@babel/runtime": "^7.12.0"
           }
         },
-        "jest-diff": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-          "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^26.6.2",
-            "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.6.2"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
         "lint-staged": {
           "version": "10.5.4",
           "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.5.4.tgz",
@@ -62688,24 +62543,6 @@
             "string-argv": "0.3.1",
             "stringify-object": "^3.3.0"
           }
-        },
-        "pretty-format": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.2",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^17.0.1"
-          }
-        },
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true
         },
         "semver": {
           "version": "7.3.8",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -102,7 +102,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.4.0",
     "@types/classnames": "^2.2.11",
-    "@types/jest": "^26.0.24",
+    "@types/jest": "^27.4.0",
     "@types/markdown-it": "^12.2.1",
     "@types/qrcode": "^1.4.0",
     "@types/react-dom": "^18.0.10",


### PR DESCRIPTION
## Summary

An error arises when executing npm install within the CI/CD environment. Resolving the conflicting peer dependencies may potentially rectify this issue. 

The conflict in peer dependencies involves @types/jest and React. Although the issue with @types/jest was successfully resolved, addressing the conflict with React proved to be challenging due to StoryBook (in the current installed version) relying on versions "^16.8.4 || ^17.0.0". I endeavored to update the version of StoryBook; however, the process was not as straightforward as anticipated. 

Ultimately, I resolved the conflicting peer dependencies as much as possible and added the "--legacy-peer-deps" option.


## Checklist
- [ ] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
