### PR TITLE
fix: replace addEndpointButton

### DIFF
--- a/.changeset/kind-readers-invent.md
+++ b/.changeset/kind-readers-invent.md
@@ -1,0 +1,6 @@
+---
+"@viron/app": patch
+---
+
+Replaced AddEndpointButton from FilledButton to OutlineButton.
+OutlineButton's outline color was not &{cs}-low, so the color was changed.

--- a/packages/app/src/components/button/outline/index.tsx
+++ b/packages/app/src/components/button/outline/index.tsx
@@ -109,20 +109,13 @@ const Renewal = function <T = null>({
     onClick(data as T);
   }, [data, onClick]);
 
-  const normalStyle = `bg-thm-${cs} hover:bg-thm-on-${cs}-slight text-thm-on-${cs} border-thm-on-${cs}-low`;
-  const olStyle = `bg-thm-background hover:bg-thm-on-background-slight text-thm-${cs} border-thm-${cs}`;
-
-  let buttonStyle = normalStyle;
-  if (cs === 'primary') {
-    buttonStyle = olStyle;
-  }
   return (
     <button
       style={{
         paddingLeft: pl,
       }}
       className={classnames(
-        `flex items-center gap-1 px-3 py-2 active:opacity-50 focus:outline outline-4 outline-thm-outline border`,
+        `flex items-center gap-1 px-3 py-2 active:opacity-50 focus:outline outline-4 outline-thm-outline border bg-thm-background hover:bg-thm-on-${cs} text-thm-${cs} border-thm-${cs}`,
         {
           'rounded-full': rounded,
           'text-xxs': size === SIZE.XXS,
@@ -132,7 +125,6 @@ const Renewal = function <T = null>({
           'text-xl': size === SIZE.XL,
           'text-2xl': size === SIZE['2XL'],
         },
-        buttonStyle,
         className
       )}
       type={type}

--- a/packages/app/src/components/button/outline/index.tsx
+++ b/packages/app/src/components/button/outline/index.tsx
@@ -109,13 +109,20 @@ const Renewal = function <T = null>({
     onClick(data as T);
   }, [data, onClick]);
 
+  const normalStyle = `bg-thm-${cs} hover:bg-thm-on-${cs}-slight text-thm-on-${cs} border-thm-on-${cs}-low`;
+  const olStyle = `bg-thm-background hover:bg-thm-on-background-slight text-thm-${cs} border-thm-${cs}`;
+
+  let buttonStyle = normalStyle;
+  if (cs === 'primary') {
+    buttonStyle = olStyle;
+  }
   return (
     <button
       style={{
         paddingLeft: pl,
       }}
       className={classnames(
-        `flex items-center gap-1 px-3 py-2 bg-thm-${cs} hover:bg-thm-on-${cs}-slight active:opacity-50 focus:outline outline-4 outline-thm-outline text-thm-on-${cs} border border-thm-on-${cs}`,
+        `flex items-center gap-1 px-3 py-2 active:opacity-50 focus:outline outline-4 outline-thm-outline border`,
         {
           'rounded-full': rounded,
           'text-xxs': size === SIZE.XXS,
@@ -125,6 +132,7 @@ const Renewal = function <T = null>({
           'text-xl': size === SIZE.XL,
           'text-2xl': size === SIZE['2XL'],
         },
+        buttonStyle,
         className
       )}
       type={type}

--- a/packages/app/src/components/button/outline/on/index.tsx
+++ b/packages/app/src/components/button/outline/on/index.tsx
@@ -3,14 +3,14 @@ import React, { useCallback } from 'react';
 import { Props as BaseProps } from '~/components';
 import { Props as BaseButtonProps, SIZE } from '~/components/button';
 
-export type Props<T = null> = BaseProps &
+export type Props<T = null> = BaseProps<'cs'> &
   BaseButtonProps<T> & {
     label: string;
     Icon?: React.FC<React.ComponentProps<'svg'>>;
     IconRight?: React.FC<React.ComponentProps<'svg'>>;
   };
 const OutlineButton = function <T = null>({
-  on,
+  cs,
   className = '',
   label,
   Icon,
@@ -40,7 +40,7 @@ const OutlineButton = function <T = null>({
             paddingLeft: pl,
           }}
           className={classnames(
-            `absolute inset-0 pointer-events-none bg-thm-on-${on} opacity-0 group-hover:opacity-25 group-active:opacity-50`,
+            `absolute inset-0 pointer-events-none bg-thm-on-${cs} opacity-0 group-hover:opacity-25 group-active:opacity-50`,
             {
               rounded: rounded,
             }
@@ -51,7 +51,7 @@ const OutlineButton = function <T = null>({
             paddingLeft: pl,
           }}
           className={classnames(
-            `absolute inset-0 pointer-events-none opacity-50 group-focus:ring-4 group-focus:ring-thm-on-${on}`,
+            `absolute inset-0 pointer-events-none opacity-50 group-focus:ring-4 group-focus:ring-thm-on-${cs}`,
             {
               rounded: rounded,
             }
@@ -62,7 +62,7 @@ const OutlineButton = function <T = null>({
             paddingLeft: pl,
           }}
           className={classnames(
-            `relative flex items-center gap-1 px-2 py-1 border border-thm-on-${on} text-thm-on-${on}`,
+            `relative flex items-center gap-1 px-2 py-1 border border-thm-on-${cs} text-thm-on-${cs}`,
             {
               'text-xxs': size === SIZE.XXS,
               'text-xs': size === SIZE.XS,
@@ -90,4 +90,61 @@ const OutlineButton = function <T = null>({
     </button>
   );
 };
+
+const Renewal = function <T = null>({
+  cs,
+  className = '',
+  label,
+  Icon,
+  IconRight,
+  disabled = false,
+  type = 'button',
+  size = SIZE.SM,
+  data,
+  onClick,
+  rounded = true,
+  pl,
+}: React.PropsWithChildren<Props<T>>): JSX.Element {
+  const handleClick = useCallback(() => {
+    onClick(data as T);
+  }, [data, onClick]);
+
+  return (
+    <button
+      style={{
+        paddingLeft: pl,
+      }}
+      className={classnames(
+        `flex items-center gap-1 px-3 py-2 active:opacity-50 focus:outline outline-4 outline-thm-outline border bg-thm-${cs} hover:bg-thm-on-${cs}-slight text-thm-on-${cs} border-thm-on-${cs}-low`,
+        {
+          'rounded-full': rounded,
+          'text-xxs': size === SIZE.XXS,
+          'text-xs': size === SIZE.XS,
+          'text-sm': size === SIZE.SM,
+          'text-base': size === SIZE.BASE,
+          'text-xl': size === SIZE.XL,
+          'text-2xl': size === SIZE['2XL'],
+        },
+        className
+      )}
+      type={type}
+      disabled={disabled}
+      onClick={handleClick}
+    >
+      {Icon && (
+        <span className="flex-none">
+          <Icon className="w-[1.2em]" />
+        </span>
+      )}
+      {label && <span className="flex-1 truncate">{label}</span>}
+      {IconRight && (
+        <span className="flex-none">
+          <IconRight className="w-[1.2em]" />
+        </span>
+      )}
+    </button>
+  );
+};
+
+OutlineButton.renewal = Renewal;
 export default OutlineButton;

--- a/packages/app/src/pages/dashboard/endpoints/_/body/add/index.tsx
+++ b/packages/app/src/pages/dashboard/endpoints/_/body/add/index.tsx
@@ -124,7 +124,7 @@ const AddEndpoint: React.FC<Props> = ({ className = '', onAdd, onCancel }) => {
         </div>
         <div className="flex justify-end gap-2">
           <OutlineButton
-            on={COLOR_SYSTEM.SURFACE}
+            cs={COLOR_SYSTEM.SURFACE}
             size={BUTTON_SIZE.BASE}
             label={t('addEndpoint.cancelButtonLabel')}
             onClick={handleCancelClick}

--- a/packages/app/src/pages/dashboard/endpoints/_/body/index.tsx
+++ b/packages/app/src/pages/dashboard/endpoints/_/body/index.tsx
@@ -1,8 +1,8 @@
 import classnames from 'classnames';
 import React, { useCallback, useState } from 'react';
-import FilledButton, {
-  Props as FilledButtonProps,
-} from '~/components/button/filled';
+import OutlineButton, {
+  Props as OutlineButtonProps,
+} from '~/components/button/outline';
 import TextButton, {
   Props as TextButtonProps,
 } from '~/components/button/text/on';
@@ -10,7 +10,7 @@ import Head from '~/components/head';
 import ChevronDownIcon from '~/components/icon/chevronDown/outline';
 import ChevronRightIcon from '~/components/icon/chevronRight/outline';
 import ColorSwatchIcon from '~/components/icon/colorSwatch/outline';
-import PlusCircleIcon from '~/components/icon/plusCircle/outline';
+import PlusIcon from '~/components/icon/plus/outline';
 import { useEndpoint } from '~/hooks/endpoint';
 import { useTranslation } from '~/hooks/i18n';
 import { Props as LayoutProps } from '~/layouts/';
@@ -27,7 +27,7 @@ const Body: React.FC<Props> = ({ className, style }) => {
 
   // Add modal.
   const modal = useModal();
-  const handleAddClick = useCallback<FilledButtonProps['onClick']>(() => {
+  const handleAddClick = useCallback<OutlineButtonProps['onClick']>(() => {
     modal.open();
   }, [modal.open]);
   const handleAddAdd = useCallback<AddProps['onAdd']>(() => {
@@ -62,10 +62,10 @@ const Body: React.FC<Props> = ({ className, style }) => {
           {/* Body */}
           <div className="">
             <div className="p-4 flex justify-end border-b border-thm-on-background-slight">
-              <FilledButton
+              <OutlineButton.renewal
                 cs={COLOR_SYSTEM.PRIMARY}
                 label={t('addEndpointButtonLabel')}
-                Icon={PlusCircleIcon}
+                Icon={PlusIcon}
                 onClick={handleAddClick}
               />
             </div>

--- a/packages/app/src/pages/dashboard/endpoints/_/body/item/index.tsx
+++ b/packages/app/src/pages/dashboard/endpoints/_/body/item/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import OutlineButton, {
-  Props as OutlineButtonProps,
-} from '~/components/button/outline';
+import OutlineOnButton, {
+  Props as OutlineOnButtonProps,
+} from '~/components/button/outline/on';
 import TextButton, {
   Props as TextButtonProps,
 } from '~/components/button/text/on';
@@ -149,7 +149,7 @@ const _Item: React.FC<{
     removeEndpoint(endpoint.id);
   }, [endpoint, removeEndpoint, menuPopover]);
 
-  const handleEnterClick = useCallback<OutlineButtonProps['onClick']>(() => {
+  const handleEnterClick = useCallback<OutlineOnButtonProps['onClick']>(() => {
     navigate(endpoint);
   }, [endpoint, navigate]);
 
@@ -193,7 +193,7 @@ const _Item: React.FC<{
         <div className="flex items-center gap-2 justify-end">
           {document ? (
             <>
-              <OutlineButton.renewal
+              <OutlineOnButton.renewal
                 className="grow max-w-50%"
                 cs={COLOR_SYSTEM.BACKGROUND}
                 IconRight={TerminalIcon}

--- a/packages/app/src/pages/dashboard/groups/_/body/add/index.tsx
+++ b/packages/app/src/pages/dashboard/groups/_/body/add/index.tsx
@@ -97,7 +97,7 @@ const Add: React.FC<Props> = ({ onAdd, onCancel }) => {
         </div>
         <div className="flex justify-end gap-2">
           <OutlineButton
-            on={COLOR_SYSTEM.SURFACE}
+            cs={COLOR_SYSTEM.SURFACE}
             label="Cancel"
             onClick={handleCancelClick}
           />

--- a/packages/app/src/pages/dashboard/groups/_/body/item/index.tsx
+++ b/packages/app/src/pages/dashboard/groups/_/body/item/index.tsx
@@ -156,7 +156,7 @@ const RemoveConfirmation: React.FC<RemoveConfirmationProps> = ({
       />
       <div className="flex justify-end gap-2">
         <OutlineOnButton
-          on={COLOR_SYSTEM.SURFACE}
+          cs={COLOR_SYSTEM.SURFACE}
           label="Cancel"
           onClick={handleCancelClick}
         />


### PR DESCRIPTION
## Summary
Replaced AddEndpointButton from FilledButton to OutlineButton.
OutlineButton's outline color was not &{cs}-low, so the color was changed.
Created a new OutlineOnButton.renewal component and accordingly changed the on of the old OutlineButton's Props to cs.

## Reference(s)
before|after
--|--
<img width="780" alt="スクリーンショット 2023-07-07 午後5 54 47" src="https://github.com/cam-inc/viron/assets/74092547/abd263b3-c266-4cb2-9eaa-01a597ed279c">|<img width="780" alt="スクリーンショット 2023-07-07 午後5 44 05" src="https://github.com/cam-inc/viron/assets/74092547/13c0caa7-04ba-408e-930c-b762e9c82572">

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
