### PR TITLE
fix: signin and signout buttons changed to renewal 

### DIFF
--- a/.changeset/unlucky-panthers-rule.md
+++ b/.changeset/unlucky-panthers-rule.md
@@ -1,0 +1,6 @@
+---
+"@viron/app": patch
+---
+
+Enlarged navigation icon.
+Added OutlineTwitter icon.

--- a/packages/app/src/pages/dashboard/endpoints/_/body/item/index.tsx
+++ b/packages/app/src/pages/dashboard/endpoints/_/body/item/index.tsx
@@ -200,6 +200,7 @@ const _Item: React.FC<{
                 label={t('enterEndpoint')}
                 onClick={handleEnterClick}
               />
+
               {authentication.list.find((item) => item.type === 'signout') && (
                 <Signout
                   endpoint={endpoint}
@@ -209,7 +210,9 @@ const _Item: React.FC<{
               )}
             </>
           ) : (
-            <Signin endpoint={endpoint} authentication={authentication} />
+            <div className="flex-1">
+              <Signin endpoint={endpoint} authentication={authentication} />
+            </div>
           )}
         </div>
       </div>

--- a/packages/app/src/pages/dashboard/endpoints/_/body/item/signin/index.tsx
+++ b/packages/app/src/pages/dashboard/endpoints/_/body/item/signin/index.tsx
@@ -43,17 +43,19 @@ const Signin: React.FC<Props> = ({ endpoint, authentication }) => {
     <>
       <div className="flex items-center gap-2">
         {authConfigOAuth && (
-          <FilledButton
+          <FilledButton.renewal
+            className="grow max-w-50%"
             cs={COLOR_SYSTEM.PRIMARY}
-            Icon={LoginIcon}
+            IconRight={LoginIcon}
             label={t('oAuth')}
             onClick={handleOAuthClick}
           />
         )}
         {authConfigEmail && (
-          <FilledButton
+          <FilledButton.renewal
+            className="grow max-w-50%"
             cs={COLOR_SYSTEM.PRIMARY}
-            Icon={LoginIcon}
+            IconRight={LoginIcon}
             label={t('email')}
             onClick={handleEmailClick}
           />

--- a/packages/app/src/pages/dashboard/endpoints/_/body/item/signout/index.tsx
+++ b/packages/app/src/pages/dashboard/endpoints/_/body/item/signout/index.tsx
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import React, { useCallback, useMemo } from 'react';
-import FilledButton, {
-  Props as FilledButtonProps,
-} from '~/components/button/filled';
+import OutlineButton, {
+  Props as OutlineButtonProps,
+} from '~/components/button/outline';
 import Error from '~/components/error';
 import LogoutIcon from '~/components/icon/logout/outline';
 import Request from '~/components/request';
@@ -26,7 +26,7 @@ const Signout: React.FC<Props> = ({ endpoint, authentication, onSignout }) => {
   );
 
   const drawer = useDrawer();
-  const handleClick = useCallback<FilledButtonProps['onClick']>(() => {
+  const handleClick = useCallback<OutlineButtonProps['onClick']>(() => {
     drawer.open();
   }, [drawer]);
 
@@ -51,9 +51,10 @@ const Signout: React.FC<Props> = ({ endpoint, authentication, onSignout }) => {
 
   return (
     <>
-      <FilledButton
-        cs={COLOR_SYSTEM.SECONDARY}
-        Icon={LogoutIcon}
+      <OutlineButton.renewal
+        className="grow max-w-50%"
+        cs={COLOR_SYSTEM.BACKGROUND}
+        IconRight={LogoutIcon}
         label={t('signout')}
         onClick={handleClick}
       />


### PR DESCRIPTION
## Summary
signin and signout buttons changed to renewal.
url: [https://localhost:8000/dashboard/endpoints/](https://localhost:8000/dashboard/endpoints/)

## Reference(s)
before|after
-|-
<img width="532" alt="スクリーンショット 2023-07-07 午後4 02 48" src="https://github.com/cam-inc/viron/assets/74092547/4526c645-ad15-45d5-a584-ef94eb9928f2">|<img width="532" alt="スクリーンショット 2023-07-07 午後4 02 48" src="https://github.com/cam-inc/viron/assets/74092547/0c4257b0-2844-427d-bfb9-be51fd1d44de">
-|-
<img width="515" alt="スクリーンショット 2023-07-07 午後4 37 43" src="https://github.com/cam-inc/viron/assets/74092547/ac6e4e26-f66e-4b44-af0a-16e92296147a">|<img width="515" alt="スクリーンショット 2023-07-07 午後4 37 43" src="https://github.com/cam-inc/viron/assets/74092547/7e0328b4-0b25-443d-8096-ffd7a4298e6e">
-|-
<img width="516" alt="スクリーンショット 2023-07-07 午後4 40 17" src="https://github.com/cam-inc/viron/assets/74092547/207b650e-0e3d-44b5-8c2d-9a8ebd95efee">|<img width="516" alt="スクリーンショット 2023-07-07 午後4 40 17" src="https://github.com/cam-inc/viron/assets/74092547/7643f347-25ca-42c3-b86b-41b2fd42a6fc">

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included