### PR TITLE
fix: signout button

### DIFF
--- a/.changeset/friendly-years-serve.md
+++ b/.changeset/friendly-years-serve.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+Added changes to components due to changes to OutlineButton.

--- a/packages/app/src/pages/dashboard/endpoints/_/body/item/index.tsx
+++ b/packages/app/src/pages/dashboard/endpoints/_/body/item/index.tsx
@@ -200,7 +200,6 @@ const _Item: React.FC<{
                 label={t('enterEndpoint')}
                 onClick={handleEnterClick}
               />
-
               {authentication.list.find((item) => item.type === 'signout') && (
                 <Signout
                   endpoint={endpoint}

--- a/packages/app/src/pages/dashboard/endpoints/_/body/item/signout/index.tsx
+++ b/packages/app/src/pages/dashboard/endpoints/_/body/item/signout/index.tsx
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import React, { useCallback, useMemo } from 'react';
-import OutlineButton, {
-  Props as OutlineButtonProps,
-} from '~/components/button/outline';
+import OutlineOnButton, {
+  Props as OutlineOnButtonProps,
+} from '~/components/button/outline/on';
 import Error from '~/components/error';
 import LogoutIcon from '~/components/icon/logout/outline';
 import Request from '~/components/request';
@@ -26,7 +26,7 @@ const Signout: React.FC<Props> = ({ endpoint, authentication, onSignout }) => {
   );
 
   const drawer = useDrawer();
-  const handleClick = useCallback<OutlineButtonProps['onClick']>(() => {
+  const handleClick = useCallback<OutlineOnButtonProps['onClick']>(() => {
     drawer.open();
   }, [drawer]);
 
@@ -51,7 +51,7 @@ const Signout: React.FC<Props> = ({ endpoint, authentication, onSignout }) => {
 
   return (
     <>
-      <OutlineButton.renewal
+      <OutlineOnButton.renewal
         className="grow max-w-50%"
         cs={COLOR_SYSTEM.BACKGROUND}
         IconRight={LogoutIcon}


### PR DESCRIPTION
## Summary

Added changes to components due to changes to OutlineButton.

## Reference(s)

before|after
-|-
<img width="285" alt="スクリーンショット 2023-07-14 午後3 49 31" src="https://github.com/cam-inc/viron/assets/74092547/f5fe4d57-e721-4ad0-963e-cdc20e6e69a1">|<img width="285" alt="スクリーンショット 2023-07-14 午後3 50 13" src="https://github.com/cam-inc/viron/assets/74092547/5c8bacf4-ebbe-4d38-9416-33b397427b9a">



## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
