### PR TITLE
fix: head component

### DIFF
--- a/.changeset/quick-pans-run.md
+++ b/.changeset/quick-pans-run.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+Renewed design of Head component on dashboard page.

--- a/packages/app/src/components/head/index.tsx
+++ b/packages/app/src/components/head/index.tsx
@@ -11,7 +11,7 @@ const Head: React.FC<Props> = ({ on, className = '', title, description }) => {
     <div className={classnames('', className)}>
       <div className={`text-thm-on-${on} text-2xl font-bold`}>{title}</div>
       {description && (
-        <div className={`text-thm-on-${on}-low text-sm mt-2`}>
+        <div className={`text-thm-on-${on}-low text-xs mt-1`}>
           {description}
         </div>
       )}

--- a/packages/app/src/pages/dashboard/endpoints/_/body/index.tsx
+++ b/packages/app/src/pages/dashboard/endpoints/_/body/index.tsx
@@ -43,15 +43,10 @@ const Body: React.FC<Props> = ({ className, style }) => {
         <div className="">
           {/* Head */}
           <div>
-            <div className="p-4">
+            <div className="py-6 pl-8">
               <Head
                 on={COLOR_SYSTEM.BACKGROUND}
-                title={
-                  <div className="flex items-center gap-2">
-                    <ColorSwatchIcon className="w-em" />
-                    <div>{t('dashboard.endpoints.title')}</div>
-                  </div>
-                }
+                title={<div>{t('dashboard.endpoints.title')}</div>}
                 description={t('dashboard.endpoints.description')}
               />
             </div>


### PR DESCRIPTION
## Summary

Renewed design of Head component on dashboard page.

## Reference(s)

before|after
-|-
<img width="500" alt="スクリーンショット 2023-07-14 午後5 08 13" src="https://github.com/cam-inc/viron/assets/74092547/c7ef8559-28f6-4ea0-80f6-c0048875a71d">|<img width="500" alt="スクリーンショット 2023-07-14 午後5 05 43" src="https://github.com/cam-inc/viron/assets/74092547/3d65d0bb-ecf9-4c7c-8274-a23295486836">

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
