### PR TITLE
fix: dashboard tabs

### DIFF
--- a/.changeset/thick-files-explain.md
+++ b/.changeset/thick-files-explain.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+Renewed the design of the Tabs component on the dashboard page.g

--- a/packages/app/src/components/tabs/index.tsx
+++ b/packages/app/src/components/tabs/index.tsx
@@ -51,21 +51,15 @@ const Renewal: React.FC<Props> = ({ on, className = '', list, onChange }) => {
         {list.map((item) => (
           <li
             key={item.id}
-            className={classnames(
-              'block border-thm-primary w-full max-w-[178px]',
-              {
-                'border-b-2': item.isActive,
-              }
-            )}
+            className={classnames('w-[178px]', {
+              'border-b-2 border-thm-primary': item.isActive,
+            })}
           >
             <button
               onClick={() => handleItemClick(item.id)}
-              className={classnames(
-                `block p-2  w-full text-sm border-thm-on-${on}-low`,
-                {
-                  'font-bold': item.isActive,
-                }
-              )}
+              className={classnames(`block p-2 w-full text-sm`, {
+                'font-bold': item.isActive,
+              })}
             >
               {item.label}
             </button>

--- a/packages/app/src/components/tabs/index.tsx
+++ b/packages/app/src/components/tabs/index.tsx
@@ -9,7 +9,9 @@ export type Props = BaseProps & {
   list: Omit<ItemProps, 'on' | 'className' | 'onClick'>[];
   onChange: (id: ItemProps['id']) => void;
 };
-const Tabs: React.FC<Props> = ({ on, className = '', list, onChange }) => {
+const Tabs: React.FC<Props> & {
+  renewal: React.FC<Props>;
+} = ({ on, className = '', list, onChange }) => {
   const handleItemClick = useCallback<ItemProps['onClick']>(
     (id) => {
       onChange(id);
@@ -34,6 +36,47 @@ const Tabs: React.FC<Props> = ({ on, className = '', list, onChange }) => {
     </div>
   );
 };
+
+const Renewal: React.FC<Props> = ({ on, className = '', list, onChange }) => {
+  const handleItemClick = useCallback<ItemProps['onClick']>(
+    (id) => {
+      onChange(id);
+    },
+    [onChange]
+  );
+
+  return (
+    <div className={className}>
+      <ul className={`flex border-b border-thm-on-${on}-slight`}>
+        {list.map((item) => (
+          <li
+            key={item.id}
+            className={classnames(
+              'block border-thm-primary w-full max-w-[178px]',
+              {
+                'border-b-2': item.isActive,
+              }
+            )}
+          >
+            <button
+              onClick={() => handleItemClick(item.id)}
+              className={classnames(
+                `block p-2  w-full text-sm border-thm-on-${on}-low`,
+                {
+                  'font-bold': item.isActive,
+                }
+              )}
+            >
+              {item.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+Tabs.renewal = Renewal;
+
 export default Tabs;
 
 type ItemProps = BaseProps & {

--- a/packages/app/src/components/tabs/index.tsx
+++ b/packages/app/src/components/tabs/index.tsx
@@ -57,7 +57,7 @@ const Renewal: React.FC<Props> = ({ on, className = '', list, onChange }) => {
           >
             <button
               onClick={() => handleItemClick(item.id)}
-              className={classnames(`block p-2 w-full text-sm`, {
+              className={classnames('block p-2 w-full text-sm', {
                 'font-bold': item.isActive,
               })}
             >

--- a/packages/app/src/pages/dashboard/_/tabs/index.tsx
+++ b/packages/app/src/pages/dashboard/_/tabs/index.tsx
@@ -40,7 +40,11 @@ const _Tabs: React.FC<Props> = ({ item }) => {
 
   return (
     <div>
-      <Tabs on={COLOR_SYSTEM.BACKGROUND} list={list} onChange={handleChange} />
+      <Tabs.renewal
+        on={COLOR_SYSTEM.BACKGROUND}
+        list={list}
+        onChange={handleChange}
+      />
     </div>
   );
 };

--- a/packages/app/src/pages/dashboard/groups/_/body/index.tsx
+++ b/packages/app/src/pages/dashboard/groups/_/body/index.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from '~/hooks/i18n';
 import { Props as LayoutProps } from '~/layouts/index';
 import Modal, { useModal } from '~/portals/modal';
 import { COLOR_SYSTEM } from '~/types';
-import Tabs, { ITEM as TABS_ITEM } from '../../../_/tabs/';
+import Tabs, { ITEM as TABS_ITEM } from '../../../_/tabs';
 import Add, { Props as AddProps } from './add/';
 import Item from './item';
 


### PR DESCRIPTION
## Summary

Renewed the design of the Tabs component on the dashboard page

## Reference(s)

before|after
-|-
<img width="490" alt="スクリーンショット 2023-07-14 午後6 56 25" src="https://github.com/cam-inc/viron/assets/74092547/05c1f34f-35ea-415e-b06b-96f99680c15e">|<img width="490" alt="スクリーンショット 2023-07-14 午後6 57 09" src="https://github.com/cam-inc/viron/assets/74092547/f9bc6f63-d975-49c2-961e-ddf28474a09d">

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
