### PR TITLE
fix: internal pages component

### DIFF
--- a/.changeset/tame-parrots-fix.md
+++ b/.changeset/tame-parrots-fix.md
@@ -3,3 +3,5 @@
 ---
 
 Renewed internalPages of navigation component.
+Changed font size to 14px and changed icon size setting accordingly.
+

--- a/.changeset/tame-parrots-fix.md
+++ b/.changeset/tame-parrots-fix.md
@@ -2,4 +2,4 @@
 "@viron/app": patch
 ---
 
-Renewed navigation component.
+Renewed internalPages of navigation component.

--- a/.changeset/tame-parrots-fix.md
+++ b/.changeset/tame-parrots-fix.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+Renewed navigation component.

--- a/packages/app/src/components/navigation/internalPages/index.tsx
+++ b/packages/app/src/components/navigation/internalPages/index.tsx
@@ -40,9 +40,9 @@ const InternalPages: React.FC<Props> = ({ className = '', on }) => {
             className={classNames(
               'flex gap-2 text-xs items-center pl-1 py-1 rounded-lg active:opacity-50',
               {
-                [`bg-thm-on-${on}-low text-thm-on-${on}-faint hover:bg-thm-on-${on}-low focus:outline outline-2 outline-thm-${on}`]:
+                [`bg-thm-on-${on}-low text-thm-on-${on}-faint hover:opacity-75 focus:outline outline-2 outline-thm-${on}`]:
                   item.to === originalPath,
-                [`text-thm-on-${on} hover:bg-thm-on-${on}-low hover:text-thm-${on} focus:outline outline-2 outline-thm-${on}`]:
+                [`text-thm-on-${on}  hover:opacity-75 focus:outline outline-2 outline-thm-${on}`]:
                   item.to !== originalPath,
               }
             )}

--- a/packages/app/src/components/navigation/internalPages/index.tsx
+++ b/packages/app/src/components/navigation/internalPages/index.tsx
@@ -17,12 +17,12 @@ const paths: {
   {
     to: INTERNAL_PAGE_PATHS.ROOT,
     label: 'internalPagePaths.root',
-    icon: <HomeOutlineIcon className="w-em" />,
+    icon: <HomeOutlineIcon className="w-[1.75em] h-[1.75em]" />,
   },
   {
     to: INTERNAL_PAGE_PATHS.ENDPOINTS,
     label: 'internalPagePaths.endpoints',
-    icon: <BarsOutLineIcon className="w-em" />,
+    icon: <BarsOutLineIcon className="w-[1.75em] h-[1.75em]" />,
   },
 ];
 
@@ -38,9 +38,9 @@ const InternalPages: React.FC<Props> = ({ className = '', on }) => {
         <li key={item.to}>
           <Link
             className={classNames(
-              'flex gap-1 text-xs items-center pl-2 py-1 rounded-lg active:opacity-50',
+              'flex gap-2 text-xs items-center pl-1 py-1 rounded-lg active:opacity-50',
               {
-                [`bg-thm-on-${on} text-thm-${on} hover:bg-thm-on-${on}-low focus:outline outline-2 outline-thm-${on}`]:
+                [`bg-thm-on-${on}-low text-thm-on-${on}-faint hover:bg-thm-on-${on}-low focus:outline outline-2 outline-thm-${on}`]:
                   item.to === originalPath,
                 [`text-thm-on-${on} hover:bg-thm-on-${on}-low hover:text-thm-${on} focus:outline outline-2 outline-thm-${on}`]:
                   item.to !== originalPath,

--- a/packages/app/src/components/navigation/internalPages/index.tsx
+++ b/packages/app/src/components/navigation/internalPages/index.tsx
@@ -17,12 +17,12 @@ const paths: {
   {
     to: INTERNAL_PAGE_PATHS.ROOT,
     label: 'internalPagePaths.root',
-    icon: <HomeOutlineIcon className="w-[1.75em] h-[1.75em]" />,
+    icon: <HomeOutlineIcon className="w-[1.42em] h-[1.42em]" />,
   },
   {
     to: INTERNAL_PAGE_PATHS.ENDPOINTS,
     label: 'internalPagePaths.endpoints',
-    icon: <BarsOutLineIcon className="w-[1.75em] h-[1.75em]" />,
+    icon: <BarsOutLineIcon className="w-[1.42em] h-[1.42em]" />,
   },
 ];
 
@@ -38,7 +38,7 @@ const InternalPages: React.FC<Props> = ({ className = '', on }) => {
         <li key={item.to}>
           <Link
             className={classNames(
-              'flex gap-2 text-xs items-center pl-1 py-1 rounded-lg active:opacity-50',
+              'flex gap-2 text-sm items-center pl-1 py-1 rounded-lg active:opacity-50',
               {
                 [`bg-thm-on-${on}-low text-thm-on-${on}-faint hover:opacity-75 focus:outline outline-2 outline-thm-${on}`]:
                   item.to === originalPath,

--- a/packages/app/src/components/navigation/links/index.tsx
+++ b/packages/app/src/components/navigation/links/index.tsx
@@ -70,10 +70,10 @@ const Renewal: React.FC<Props> = ({ className = '', on }) => {
       {links.map((item) => (
         <li key={item.to}>
           <Link
-            className={`flex gap-2 text-xs items-center text-thm-on-${on} hover:underline active:text-thm-on-${on}-low focus:outline outline-2 outline-thm-outline`}
+            className={`flex gap-2 text-sm items-center text-thm-on-${on} hover:underline active:text-thm-on-${on}-low focus:outline outline-2 outline-thm-outline`}
             to={item.to}
           >
-            {item.isExternal && <ExternalLinkIcon className="w-[1.75em]" />}
+            {item.isExternal && <ExternalLinkIcon className="w-[1.42em]" />}
             <div>{t(item.label)}</div>
           </Link>
         </li>

--- a/packages/app/src/components/navigation/services/index.tsx
+++ b/packages/app/src/components/navigation/services/index.tsx
@@ -18,13 +18,13 @@ const services: ServiceType[] = [
   {
     i18nKey: 'service.twitter',
     to: URL.TWITTER,
-    icon: <TwitterIcon className="w-[1.75em] h-[1.75em]" />,
+    icon: <TwitterIcon className="w-[1.42em] h-[1.42em]" />,
     isComingSoon: true,
   },
   {
     i18nKey: 'service.github',
     to: URL.GITHUB,
-    icon: <GithubIcon className="w-[1.75em] h-[1.75em]" />,
+    icon: <GithubIcon className="w-[1.42em] h-[1.42em]" />,
   },
 ];
 
@@ -112,7 +112,7 @@ const ServiceRenewal: React.FC<ServiceProps> = ({ on, service }) => {
     <>
       {!service.isComingSoon ? (
         <Link
-          className={`flex gap-2 text-xs items-center text-thm-on-${on} hover:underline active:text-thm-on-${on}-low focus:outline outline-2 outline-thm-outline`}
+          className={`flex gap-2 text-sm items-center text-thm-on-${on} hover:underline active:text-thm-on-${on}-low focus:outline outline-2 outline-thm-outline`}
           to={service.to}
         >
           {service.icon}
@@ -120,7 +120,7 @@ const ServiceRenewal: React.FC<ServiceProps> = ({ on, service }) => {
         </Link>
       ) : (
         <button
-          className={`flex gap-2 text-xs items-center text-thm-on-${on} hover:underline active:text-thm-on-${on}-low focus:outline outline-2 outline-thm-outline`}
+          className={`flex gap-2 text-sm items-center text-thm-on-${on} hover:underline active:text-thm-on-${on}-low focus:outline outline-2 outline-thm-outline`}
           ref={popover.targetRef}
           onClick={handleButtonClick}
         >

--- a/packages/app/src/pages/dashboard/_/navigation/index.tsx
+++ b/packages/app/src/pages/dashboard/_/navigation/index.tsx
@@ -35,7 +35,7 @@ const _Navigation: React.FC<Props> = ({ className, style }) => {
       return (
         <NavigationInternalPages
           className="mx-2 space-y-1"
-          on={COLOR_SYSTEM.BACKGROUND}
+          on={COLOR_SYSTEM.SURFACE}
         />
       );
     },


### PR DESCRIPTION
## Summary

Renewed internalPages of navigation component.
Changed font size to 14px and changed icon size setting accordingly.

※The issue of navigation not being active when on the /dashboard/endpoints page is not addressed in this PR, as it may require significant changes.

## Reference(s)
before|after
-|-
<img width="200" alt="スクリーンショット 2023-07-19 午後2 47 43" src="https://github.com/cam-inc/viron/assets/74092547/c9db6330-3f33-49ca-ab04-9c4626bbea3c">|<img width="200" alt="スクリーンショット 2023-07-19 午後2 46 02" src="https://github.com/cam-inc/viron/assets/74092547/1b223697-e335-4c48-84fb-1fa9c4b75fb7">

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
