### PR TITLE
fix: i18n redirect function

### DIFF
--- a/.changeset/proud-experts-guess.md
+++ b/.changeset/proud-experts-guess.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": minor
+---
+
+Add redirect function so that oauth redirect works.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18815,19 +18815,6 @@
         "minimatch": "^7.4.2"
       }
     },
-    "node_modules/casbin-mongoose-adapter": {
-      "version": "4.0.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mongoose": "^6.0.12"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "casbin": "^5.0.7"
-      }
-    },
     "node_modules/casbin-sequelize-adapter": {
       "version": "2.7.0",
       "dependencies": {
@@ -47644,6 +47631,7 @@
         "@viron/linter": "*",
         "babel-jest": "^27.0.6",
         "babel-preset-gatsby": "^3.11.0",
+        "browser-lang": "^0.2.1",
         "classnames": "^2.2.6",
         "color-blend": "^3.0.1",
         "gatsby": "^5.11.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -57,6 +57,7 @@
     "@viron/linter": "*",
     "babel-jest": "^27.0.6",
     "babel-preset-gatsby": "^3.11.0",
+    "browser-lang": "^0.2.1",
     "classnames": "^2.2.6",
     "color-blend": "^3.0.1",
     "gatsby": "^5.11.0",

--- a/packages/app/src/wrappers/page.tsx
+++ b/packages/app/src/wrappers/page.tsx
@@ -1,10 +1,96 @@
-import { PageProps, PluginOptions } from 'gatsby';
+/**
+ * In gatsby-plugin-react-i18next, the redirect function causes a hydration error, so I am describing the modified version here.
+ * @see https://github.com/microapps/gatsby-plugin-react-i18next/blob/0cb31fe4e48dd5b1771efaf24c85ece5540aa084/src/plugin/wrapPageElement.tsx
+ */
+// @ts-ignore
+import browserLang from 'browser-lang';
+import { PageProps, PluginOptions, withPrefix } from 'gatsby';
 import React from 'react';
+
+const LANGUAGE_KEY = 'gatsby-i18next-language';
+
+type I18NextContext = {
+  language: string;
+  routed: boolean;
+  languages: string[];
+  defaultLanguage: string;
+  generateDefaultLanguagePage: boolean;
+  originalPath: string;
+  path: string;
+  siteUrl?: string;
+};
+
+type PageContext = {
+  path?: string;
+  language: string;
+  i18n: I18NextContext;
+};
+
+const removePathPrefix = (pathname: string, stripTrailingSlash: boolean) => {
+  const pathPrefix = withPrefix('/');
+  let result = pathname;
+
+  if (pathname.startsWith(pathPrefix)) {
+    result = pathname.replace(pathPrefix, '/');
+  }
+
+  if (stripTrailingSlash && result.endsWith('/')) {
+    return result.slice(0, -1);
+  }
+
+  return result;
+};
 
 type Props = {
   pluginOptions: PluginOptions;
-} & PageProps;
-const PageWrapper: React.FC<Props> = ({ children }) => {
+} & PageProps<unknown, PageContext>;
+
+const PageWrapper: React.FC<Props> = (
+  props,
+  { redirect = true, fallbackLanguage, trailingSlash }
+) => {
+  const { pageContext, location, children } = props;
+  const { routed, language, languages, defaultLanguage } = pageContext.i18n;
+
+  const isRedirect = redirect && !routed;
+
+  if (isRedirect) {
+    const { search } = location;
+
+    // Skip build, Browsers only
+    if (typeof window !== 'undefined') {
+      let detected =
+        window.localStorage.getItem(LANGUAGE_KEY) ||
+        browserLang({
+          languages,
+          fallback: fallbackLanguage || language,
+        });
+
+      if (!languages.includes(detected)) {
+        detected = language;
+      }
+
+      window.localStorage.setItem(LANGUAGE_KEY, detected);
+
+      if (detected !== defaultLanguage) {
+        const queryParams = search || '';
+        const stripTrailingSlash = trailingSlash === 'never';
+        const newUrl = withPrefix(
+          `/${detected}${removePathPrefix(
+            location.pathname,
+            stripTrailingSlash
+          )}${queryParams}${location.hash}`
+        );
+
+        // @ts-ignore
+        window.___replace(newUrl);
+
+        // The following code causes a hydration error. Inconsistency occurs between the server-rendered children and null because hydration happens while switching the URL.
+        // return null;
+      }
+    }
+  }
+
   return <>{children}</>;
 };
 


### PR DESCRIPTION
## Summary

It's hard to keep i18n language data while oauth redirecting, because oauth redirect url is constants.
I added i18n auto redirect function so that when coming back to oauth redirect url it will redirect to the page with language prefix.


## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
