### PR TITLE
Fix: Sidebars overlapping pinned panels 

### DIFF
--- a/.changeset/big-dingos-work.md
+++ b/.changeset/big-dingos-work.md
@@ -1,0 +1,6 @@
+---
+"@viron/app": patch
+---
+
+- Fix: Pinned panels overlapping sidebars
+- Fix: Scrolling overlaps breadcrumbs UI and Table

--- a/packages/app/src/layouts/index.tsx
+++ b/packages/app/src/layouts/index.tsx
@@ -166,13 +166,10 @@ const Layout: React.FC<Props> = ({
         {/* region: Sub Body */}
         {renderSubBody && (
           <div
-            className={classnames(
-              'fixed z-layout-subbody right-0 bottom-0 h-[50vh] bg-thm-background text-thm-on-background shadow-01dp border-t-2 border-thm-on-background-slight overflow-y-scroll overscroll-y-contain',
-              {
-                'left-[160px]': lg && renderNavigation,
-                'left-0': !(lg && renderNavigation),
-              }
-            )}
+            className="fixed z-layout-subbody right-0 bottom-0 h-[50vh] bg-thm-background text-thm-on-background shadow-01dp border-t-2 border-thm-on-background-slight overflow-y-scroll overscroll-y-contain"
+            style={{
+              left: lg && renderNavigation ? `${WIDTH_NAVIGATION}px` : '0',
+            }}
           >
             <ErrorBoundary on={COLOR_SYSTEM.BACKGROUND}>
               {renderSubBody({

--- a/packages/app/src/pages/endpoints/[endpointId]/_/appBar/index.tsx
+++ b/packages/app/src/pages/endpoints/[endpointId]/_/appBar/index.tsx
@@ -43,7 +43,7 @@ const Appbar: React.FC<Props> = ({
 
   return (
     <div style={style} className={className}>
-      <div className="flex gap-2 items-center h-full px-4">
+      <div className="flex gap-2 items-center h-full px-4 bg-thm-background">
         {!lg && (
           <div className="flex-none">
             <TextOnButton


### PR DESCRIPTION
## Summary

- Fix: Sidebars overlapping pinned panels 
- Fix: Scrolling overlaps breadcrumbs UI and Table

## Reference(s)

before|after
-|-
![localhost_8000_ja_endpoints_mock%20server__selectedPageId=group-1-page-1 pinnedContentIds=group-1-page-1-0 (1)](https://github.com/cam-inc/viron/assets/45055030/50bf1988-adc9-4086-879a-2395b9c2225b)|![localhost_8000_ja_endpoints_mock%20server__selectedPageId=group-1-page-1 pinnedContentIds=group-1-page-1-0](https://github.com/cam-inc/viron/assets/45055030/de402d6d-49ce-40ee-8e2f-6198b51d75cd)



## Checklist
- [ ] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
