### PR TITLE
feat: content table uri

### DIFF
--- a/.changeset/five-lobsters-hammer.md
+++ b/.changeset/five-lobsters-hammer.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+Added `uri` data type to Content Table

--- a/packages/app/src/components/table/cell/string/index.tsx
+++ b/packages/app/src/components/table/cell/string/index.tsx
@@ -10,6 +10,17 @@ export type Props = BaseProps & {
 const CellForTypeString: React.FC<Props> = ({ on, schema, value }) => {
   const content = useMemo<JSX.Element>(() => {
     switch (schema.format) {
+      case 'uri':
+        return (
+          <a
+            className={classnames(`text-sm text-thm-on-${on} underline`)}
+            href={value}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {value}
+          </a>
+        );
       case 'uri-image':
         return <img className="block" src={value} />;
       default:


### PR DESCRIPTION
## Summary

https://discovery.viron.plus/docs/Advanced-Guides/content-table#data-display

The official documentation described the data type uri of the table cell.
However, it was not implemented.

In this PR, the case where the data type is uri is added.

### Before
<img src="https://github.com/cam-inc/viron/assets/48080530/794a4208-f1b2-4786-a27e-81ec59351fc5" width="400">

### After
<img src="https://github.com/cam-inc/viron/assets/48080530/a1a19df7-6512-4eef-8498-5595ec51f266" width="400">

