### PR TITLE
fix(app): border-bottom are chipped if container doesn't have a pager 🐛

### DIFF
--- a/.changeset/tall-bikes-invite.md
+++ b/.changeset/tall-bikes-invite.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+The borders of the content container are completely clipped.

--- a/packages/app/src/pages/endpoints/[endpointId]/_/content/index.tsx
+++ b/packages/app/src/pages/endpoints/[endpointId]/_/content/index.tsx
@@ -40,7 +40,7 @@ const _Content: React.FC<Props> = ({
   return (
     <div
       id={content.id}
-      className="border border-thm-on-background-low rounded-lg"
+      className="border border-thm-on-background-low rounded-lg overflow-hidden"
     >
       <Head
         className="py-2 px-3 text-thm-on-background bg-thm-on-background-slight rounded-t-lg"


### PR DESCRIPTION
## Summary

Apply overflow style to content container to clip container body to show a border edge completely.

## Reference(s)

Provide references that relate to your PR, if any.

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
