### PR TITLE
fix(app): spinner is unnaturally placed on the far left 🐛

### DIFF
--- a/.changeset/cold-apes-drum.md
+++ b/.changeset/cold-apes-drum.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+Move spinner to the center to natural position.

--- a/packages/app/src/pages/oauthredirect/_/body/index.tsx
+++ b/packages/app/src/pages/oauthredirect/_/body/index.tsx
@@ -88,7 +88,12 @@ const Body: React.FC<Props> = ({ className = '', search }) => {
 
   if (isPending) {
     return (
-      <div className={classnames('p-4', className)}>
+      <div
+        className={classnames(
+          'p-4 flex justify-center items-center h-full',
+          className
+        )}
+      >
         <Spinner className="w-8" on={COLOR_SYSTEM.BACKGROUND} />
       </div>
     );


### PR DESCRIPTION
## Summary

The spinner in the oauthredirect page placed left edge unnaturally. Fixed to place it to center.

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
