### PR TITLE
fix(app): broken x-thumbnail will be displayed as is 🐛

### DIFF
--- a/.changeset/thick-forks-behave.md
+++ b/.changeset/thick-forks-behave.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+Hide broken x-thumbnail if error was thrown.

--- a/packages/app/src/pages/dashboard/endpoints/_/body/item/thumbnail/index.tsx
+++ b/packages/app/src/pages/dashboard/endpoints/_/body/item/thumbnail/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import Logo from '~/components/logo';
 import { Endpoint } from '~/types';
 import { Document } from '~/types/oas';
@@ -10,8 +10,9 @@ type Props = {
   className?: string;
 };
 const Thumbnail: React.FC<Props> = ({ document, className }) => {
+  const [thumbnail, setThumbnail] = useState(document?.info['x-thumbnail']);
   const elm = useMemo<JSX.Element>(() => {
-    if (!document?.info['x-thumbnail']) {
+    if (!thumbnail) {
       return (
         <div className="h-full flex items-center">
           <Logo
@@ -24,10 +25,14 @@ const Thumbnail: React.FC<Props> = ({ document, className }) => {
     return (
       <img
         className="block h-full bg-cover bg-center"
-        src={document.info['x-thumbnail']}
+        src={thumbnail}
+        alt=""
+        onError={() => {
+          setThumbnail(undefined);
+        }}
       />
     );
-  }, [document]);
+  }, [thumbnail]);
 
   return (
     <div className={classNames(className, 'rounded overflow-hidden')}>


### PR DESCRIPTION
## Summary

Endpoints typically incorporate specific access systems. This may lead to a persistent risk of associated thumbnails failing to display. 

Particularly, if the thumbnail URL is inaccessible, the broken image tag remains unaffected.
Therefore, decided to replace it to Viron’s logo as default.

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
