### PR TITLE
version: update app

### DIFF
--- a/.changeset/cold-apes-drum.md
+++ b/.changeset/cold-apes-drum.md
@@ -1,5 +1,0 @@
----
-"@viron/app": patch
----
-
-Move spinner to the center to natural position.

--- a/.changeset/thick-forks-behave.md
+++ b/.changeset/thick-forks-behave.md
@@ -1,5 +1,0 @@
----
-"@viron/app": patch
----
-
-Hide broken x-thumbnail if error was thrown.

--- a/package-lock.json
+++ b/package-lock.json
@@ -48363,7 +48363,7 @@
     },
     "packages/app": {
       "name": "@viron/app",
-      "version": "2.11.1",
+      "version": "2.11.4",
       "dependencies": {
         "@ark-ui/react": "^0.13.1",
         "@editorjs/editorjs": "^2.22.1",
@@ -48887,7 +48887,7 @@
     },
     "packages/nodejs": {
       "name": "@viron/lib",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@viron/linter": "*",

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @viron/app
 
+## 2.11.4
+
+### Patch Changes
+
+- 4204d2d2: Move spinner to the center to natural position.
+- 77798b09: Hide broken x-thumbnail if error was thrown.
+
 ## 2.11.3
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viron/app",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "engines": {
     "node": ">=18.14.0",
     "npm": ">=9.3.1"


### PR DESCRIPTION
## 2.11.4

### Patch Changes

- 4204d2d2: Move spinner to the center to natural position.
- 77798b09: Hide broken x-thumbnail if error was thrown.

## Checklist
- [x] [versioned](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#version) properly
