### PR TITLE
fix: permission error.

### DIFF
--- a/example/nodejs/Dockerfile
+++ b/example/nodejs/Dockerfile
@@ -13,7 +13,7 @@ COPY tsconfig.production.json ${HOME}/tsconfig.production.json
 COPY cert ${HOME}/cert
 
 # Setup project
-RUN npm install --no-progress && npm cache verify
+RUN npm install --no-progress --legacy-peer-deps && npm cache verify
 RUN npm run build
 
 EXPOSE 3000

--- a/example/nodejs/Dockerfile
+++ b/example/nodejs/Dockerfile
@@ -1,10 +1,8 @@
 ARG DOCKER_PROXY_HOST="docker.io"
 FROM ${DOCKER_PROXY_HOST}/node:16
 
-RUN mkdir -p /example/nodejs
-RUN chown -R root:root /example/nodejs
+USER node
 ENV HOME /example/nodejs
-USER root
 WORKDIR $HOME
 
 # Copy source files
@@ -19,6 +17,6 @@ RUN npm install --no-progress && npm cache verify
 RUN npm run build
 
 EXPOSE 3000
-USER node
+
 ENTRYPOINT ["npm"]
 CMD ["start"]

--- a/example/nodejs/Dockerfile
+++ b/example/nodejs/Dockerfile
@@ -6,11 +6,11 @@ ENV HOME /example/nodejs
 WORKDIR $HOME
 
 # Copy source files
-COPY package.json ${HOME}/package.json
-COPY src ${HOME}/src
-COPY tsconfig.json ${HOME}/tsconfig.json
-COPY tsconfig.production.json ${HOME}/tsconfig.production.json
-COPY cert ${HOME}/cert
+COPY --chown=node:node package.json ${HOME}/package.json
+COPY --chown=node:node src ${HOME}/src
+COPY --chown=node:node tsconfig.json ${HOME}/tsconfig.json
+COPY --chown=node:node tsconfig.production.json ${HOME}/tsconfig.production.json
+COPY --chown=node:node cert ${HOME}/cert
 
 # Setup project
 RUN npm install --no-progress --legacy-peer-deps && npm cache verify


### PR DESCRIPTION
# Summary

Now, accessing to demo site(https://demo.viron.plus)  returns 503 due to container is not started.

This is because that /example/nodejs/.npm folder created with root owned folder.

So, we need to define `USER node` before `RUN npm install` in Dockerfile.

updated folder permission is bellow:
```
node@182909fc783b:~$ ls -al
total 1020
drwxr-xr-x   1 node node   4096 Jan  8 16:22 .
drwxr-xr-x   1 node node   4096 Jan  8 15:44 ..
drwxr-xr-x   3 node node   4096 Jan  8 16:20 .cache
drwxr-xr-x   1 node node   4096 Jan  8 16:18 .npm
drwxr-xr-x   2 node node   4096 Jan  8 15:28 cert
drwxr-xr-x  14 node node   4096 Jan  8 16:22 dist
drwxr-xr-x 679 node node  20480 Jan  8 16:20 node_modules
-rw-r--r--   1 node node 982233 Jan  8 16:20 package-lock.json
-rw-r--r--   1 node node   3771 Jan  8 15:28 package.json
drwxr-xr-x  15 node node   4096 Jan  8 15:28 src
-rw-r--r--   1 node node    825 Jan  8 15:28 tsconfig.json
-rw-r--r--   1 node node     62 Jan  8 15:28 tsconfig.production.json
```



Switch to the `Preview` mode and **choose** a `PR template`.

Read the [Contribution guideline](https://github.com/cam-inc/viron/blob/develop/CONTRIBUTING.md).

- [General](?expand=1&template=general.md) to create any kind of PRs except for versioning.
- [Version](?expand=1&template=version.md) to set new version for packages.

---

NOTE: This is a workaround for [this](https://github.community/t/is-there-a-pull-request-template-selector-similar-to-issues/171838/8)
