### PR TITLE
fix(app): add padding to input form

### DIFF
--- a/.changeset/itchy-pens-protect.md
+++ b/.changeset/itchy-pens-protect.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+Adjusted input form padding.

--- a/.changeset/itchy-pens-protect.md
+++ b/.changeset/itchy-pens-protect.md
@@ -1,5 +1,0 @@
----
-"@viron/app": patch
----
-
-Adjusted input form padding.

--- a/packages/app/src/components/numberinput/index.tsx
+++ b/packages/app/src/components/numberinput/index.tsx
@@ -28,7 +28,7 @@ const Numberinput: React.FC<Props> = ({
     type: 'number',
     step: isFloat ? 'any' : '1',
     className: classnames(
-      'block w-full p-1 border rounded focus:outline-none focus:ring-2',
+      'block w-full p-3 border rounded focus:outline-none focus:ring-2',
       `border-thm-on-${on}-faint bg-thm-${on} text-thm-on-${on} focus:bg-thm-on-${on}-faint focus:text-thm-on-${on} focus:ring-thm-on-${on}`
     ),
   };

--- a/packages/app/src/components/select/index.tsx
+++ b/packages/app/src/components/select/index.tsx
@@ -36,7 +36,7 @@ const _Select = function <T = unknown>({
       <Select
         id={id}
         className={classnames(
-          'block w-full p-1 border rounded focus:outline-none focus:ring-2',
+          'block w-full p-3 border rounded-lg focus:outline-none focus:ring-2',
           `border-thm-on-${on}-low bg-thm-${on} text-thm-on-${on} hover:bg-thm-on-${on}-faint focus:bg-thm-on-${on}-faint focus:text-thm-on-${on} focus:ring-thm-on-${on}`
         )}
       >

--- a/packages/app/src/components/textarea/index.tsx
+++ b/packages/app/src/components/textarea/index.tsx
@@ -26,7 +26,7 @@ const Textarea: React.FC<Props> = ({
 }) => {
   const bind: Bind = {
     className: classnames(
-      'block w-full p-1 border rounded focus:outline-none focus:ring-2',
+      'block w-full p-3 border rounded focus:outline-none focus:ring-2',
       `border-thm-on-${on}-faint bg-thm-${on} text-thm-on-${on} focus:bg-thm-on-${on}-faint focus:text-thm-on-${on}  focus:ring-thm-on-${on}`
     ),
   };

--- a/packages/app/src/components/textinput/index.tsx
+++ b/packages/app/src/components/textinput/index.tsx
@@ -46,7 +46,7 @@ const Textinput: React.FC<Props> & { renewal: React.FC<RenewalProps> } = ({
   const bind: Bind = {
     type,
     id,
-    className: `block w-full p-1 border rounded border-thm-on-${on}-low bg-thm-${on} text-thm-on-${on} hover:bg-thm-on-${on}-faint focus:outline-none focus:ring-2 focus:bg-thm-on-${on}-faint focus:ring-thm-on-${on}`,
+    className: `block w-full p-3 border rounded-lg border-thm-on-${on}-low bg-thm-${on} text-thm-on-${on} hover:bg-thm-on-${on}-faint focus:outline-none focus:ring-2 focus:bg-thm-on-${on}-faint focus:ring-thm-on-${on}`,
   };
   if (autocompleteId) {
     bind.list = autocompleteId;


### PR DESCRIPTION
## Summary
Adjusted input form padding.

before|after
-|-
<img width="500" alt="スクリーンショット 2024-01-10 午後7 29 42" src="https://github.com/cam-inc/viron/assets/75605907/cfea9d21-0ed8-4ae7-935e-52ade6b3fa0b">|<img width="500" alt="スクリーンショット 2024-01-10 午後7 51 08" src="https://github.com/cam-inc/viron/assets/75605907/61ea129f-9ae9-4ea0-80ad-2f0b314a98df">



## Checklist
- [-] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
