### PR TITLE
Fix import and export button style

### DIFF
--- a/.changeset/fair-pears-tap.md
+++ b/.changeset/fair-pears-tap.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+align the label inside the button to the left

--- a/packages/app/src/components/button/index.tsx
+++ b/packages/app/src/components/button/index.tsx
@@ -98,7 +98,7 @@ const Button = function <T = null>({
           )}
         />
         {Icon && <Icon className="flex-none w-[1.2em]" />}
-        {label && <span className="flex-1 truncate text-left">{label}</span>}
+        {label && <span className="flex-1 truncate">{label}</span>}
         {IconRight && <IconRight className="flex-none w-[1.2em]" />}
       </span>
     </button>

--- a/packages/app/src/pages/dashboard/_/menu/index.tsx
+++ b/packages/app/src/pages/dashboard/_/menu/index.tsx
@@ -26,12 +26,12 @@ const Menu: React.FC<Props> = ({ className }) => {
       </div>
       {/* Menu */}
       <Popover.renewal {...menuPopover.bind}>
-        <ul className="flex flex-col gap-2">
+        <ul className="space-y-2">
           <li>
-            <Import className="w-full" />
+            <Import />
           </li>
           <li>
-            <Export className="w-full" />
+            <Export />
           </li>
         </ul>
       </Popover.renewal>


### PR DESCRIPTION
## Summary
 align the label inside the button to the left.

|before|after|
|-|-|
<img width="299" alt="スクリーンショット 2024-01-12 午後6 12 15" src="https://github.com/cam-inc/viron/assets/75605907/60c44c3b-659e-4492-b6f7-d47401a1e23e">|<img width="299" alt="スクリーンショット 2024-01-12 午後6 12 39" src="https://github.com/cam-inc/viron/assets/75605907/414b16ee-4b93-45c0-8fd3-330160c89457">

## notion
https://www.notion.so/cyberagent-group/export-import-a3baebb9db5544708c15e0c6e30c0691

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included