### PR TITLE
fix(nodejs): chore update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17889,8 +17889,9 @@
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.12",
-      "license": "MIT"
+      "version": "7.0.15",
+      "resolved": "https://caminc.jfrog.io/caminc/api/npm/default/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -17920,6 +17921,14 @@
     "node_modules/@types/lodash": {
       "version": "4.14.195",
       "license": "MIT"
+    },
+    "node_modules/@types/lodash.clonedeep": {
+      "version": "4.5.9",
+      "resolved": "https://caminc.jfrog.io/caminc/api/npm/default/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
+      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/markdown-it": {
       "version": "12.2.3",
@@ -55937,7 +55946,8 @@
       "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
-        "@viron/linter": "*",
+        "@apidevtools/json-schema-ref-parser": "^11.1.0",
+        "@viron/linter": "^0.0.2",
         "casbin": "^5.6.1",
         "casbin-mongoose-adapter": "^5.3.0",
         "casbin-sequelize-adapter": "^2.2.0",
@@ -55982,6 +55992,21 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "packages/nodejs/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.1.0",
+      "resolved": "https://caminc.jfrog.io/caminc/api/npm/default/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.1.0.tgz",
+      "integrity": "sha512-g/VW9ZQEFJAOwAyUb8JFf7MLiLy2uEB4rU270rGzDwICxnxMlPy0O11KVePSgS36K1NI29gSlK84n5INGhd4Ag==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.13",
+        "@types/lodash.clonedeep": "^4.5.7",
+        "js-yaml": "^4.1.0",
+        "lodash.clonedeep": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "packages/nodejs/node_modules/@jest/console": {
@@ -56311,6 +56336,11 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "packages/nodejs/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://caminc.jfrog.io/caminc/api/npm/default/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "packages/nodejs/node_modules/babel-jest": {
       "version": "29.6.1",
@@ -57035,6 +57065,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "packages/nodejs/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://caminc.jfrog.io/caminc/api/npm/default/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "packages/nodejs/node_modules/kareem": {

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -20,7 +20,8 @@
     "dist"
   ],
   "dependencies": {
-    "@viron/linter": "*",
+    "@apidevtools/json-schema-ref-parser": "^11.1.0",
+    "@viron/linter": "^0.0.2",
     "casbin": "^5.6.1",
     "casbin-mongoose-adapter": "^5.3.0",
     "casbin-sequelize-adapter": "^2.2.0",


### PR DESCRIPTION
## Summary
```
src/domains/oas.ts(11,33): error TS2307: Cannot find module '@apidevtools/json-schema-ref-parser' or its corresponding type declarations.
--
88 | src/domains/oas.ts(15,22): error TS2307: Cannot find module '@viron/linter' or its corresponding type declarations.
89 | src/domains/oas.ts(236,29): error TS7006: Parameter 'error' implicitly has an 'any' type.
90 | src/domains/oas.ts(236,36): error TS7006: Parameter 'i' implicitly has an 'any' type.
```
fix build package error to update dependent pacakges