### PR TITLE
add node-viron/lib codebuild file

### DIFF
--- a/codepipeline/nodejs-deployspec.yaml
+++ b/codepipeline/nodejs-deployspec.yaml
@@ -1,0 +1,22 @@
+version: 0.2
+phases:
+  install:
+    runtime-versions:
+      nodejs: latest
+
+  pre_build:
+    commands:
+      - echo Installing and building linter packages...
+      - npm install --no-progress --legacy-peer-deps && npm cache verify
+      - npm run build -w packages/linter
+      - echo Installing nodejs packages...
+      - cd ${CODEBUILD_SRC_DIR}/packages/nodejs
+      - echo Setting NPM_TOKEN...
+      - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+  build:
+    commands:
+      - echo "Building nodejs..."
+      - cd ${CODEBUILD_SRC_DIR}/packages/nodejs
+      - npm run build
+      - echo "Publishing nodejs..."
+      - npm publish

--- a/codepipeline/package-nodejs-publishspec.yml
+++ b/codepipeline/package-nodejs-publishspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: latest
+      nodejs: 18
 
   pre_build:
     commands:


### PR DESCRIPTION
## Summary
until now package-deployspec.yml is the common way to publish packages. however, node/lib depends on linter which is a monorepo package included in this project and needs to be built before publishing node-version-lib so created a new code build file for node-version-lib.