### PR TITLE
Prepare for 3pcd

### DIFF
--- a/.changeset/old-insects-occur.md
+++ b/.changeset/old-insects-occur.md
@@ -1,0 +1,5 @@
+---
+"@viron/lib": minor
+---
+
+Set partitioned cookie attributes as default

--- a/package-lock.json
+++ b/package-lock.json
@@ -58802,7 +58802,7 @@
         "casbin": "^5.6.1",
         "casbin-mongoose-adapter": "^5.3.0",
         "casbin-sequelize-adapter": "^2.2.0",
-        "cookie": "^0.4.1",
+        "cookie": "0.6.0",
         "debug": "^4.3.1",
         "deepmerge": "^4.2.2",
         "fast-copy": "^2.1.1",
@@ -58817,7 +58817,7 @@
         "uuid": "^8.3.2"
       },
       "devDependencies": {
-        "@types/cookie": "^0.4.1",
+        "@types/cookie": "0.6.0",
         "@types/debug": "^4.1.5",
         "@types/json-pointer": "^1.0.31",
         "@types/jsonwebtoken": "^8.5.1",
@@ -59167,6 +59167,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "packages/nodejs/node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true
+    },
     "packages/nodejs/node_modules/@types/yargs": {
       "version": "17.0.24",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
@@ -59321,6 +59327,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "packages/nodejs/node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "packages/nodejs/node_modules/diff-sequences": {
       "version": "29.4.3",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -25,7 +25,7 @@
     "casbin": "^5.6.1",
     "casbin-mongoose-adapter": "^5.3.0",
     "casbin-sequelize-adapter": "^2.2.0",
-    "cookie": "^0.4.1",
+    "cookie": "0.6.0",
     "debug": "^4.3.1",
     "deepmerge": "^4.2.2",
     "fast-copy": "^2.1.1",
@@ -40,7 +40,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/cookie": "^0.4.1",
+    "@types/cookie": "0.6.0",
     "@types/debug": "^4.1.5",
     "@types/json-pointer": "^1.0.31",
     "@types/jsonwebtoken": "^8.5.1",

--- a/packages/nodejs/src/helpers/cookies.ts
+++ b/packages/nodejs/src/helpers/cookies.ts
@@ -24,6 +24,9 @@ export const genCookie = (
   if (!opts.sameSite) {
     opts.sameSite = 'none';
   }
+  if (opts.partitioned === undefined) {
+    opts.partitioned = true;
+  }
   return serialize(key, value, opts);
 };
 


### PR DESCRIPTION
## Prepare for 3rd party cookie deprecation

Prepare for 3rd paty cookie deprecation using Independent Partitioned State (CHIPS)

## Not currently supported in go
Partitioned attribute of cookies is currently not supported in go
- https://github.com/golang/go/issues/62490