### PR TITLE
Fix default partitioned cookie

### DIFF
--- a/.changeset/spotty-kangaroos-shout.md
+++ b/.changeset/spotty-kangaroos-shout.md
@@ -1,0 +1,5 @@
+---
+"@viron/lib": patch
+---
+
+Set patition option is false by default

--- a/packages/nodejs/src/helpers/cookies.ts
+++ b/packages/nodejs/src/helpers/cookies.ts
@@ -25,7 +25,8 @@ export const genCookie = (
     opts.sameSite = 'none';
   }
   if (opts.partitioned === undefined) {
-    opts.partitioned = true;
+    // TODO: Set to true by default after all 3pcd support is complete
+    opts.partitioned = false;
   }
   return serialize(key, value, opts);
 };

--- a/packages/nodejs/src/helpers/cookies.ts
+++ b/packages/nodejs/src/helpers/cookies.ts
@@ -24,10 +24,10 @@ export const genCookie = (
   if (!opts.sameSite) {
     opts.sameSite = 'none';
   }
-  if (opts.partitioned === undefined) {
-    // TODO: Set to true by default after all 3pcd support is complete
-    opts.partitioned = false;
-  }
+  // TODO: Set to true by default after all 3pcd support is complete
+  // if (opts.partitioned === undefined) {
+  //   opts.partitioned = true;
+  // }
   return serialize(key, value, opts);
 };
 


### PR DESCRIPTION
## Summary

Set the default setting of patition to false until all 3pcd support is complete, as it may prevent login under certain conditions.
