### PR TITLE
Fixed a bug that caused different fileReader to be selected

### DIFF
--- a/.changeset/rich-beers-worry.md
+++ b/.changeset/rich-beers-worry.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+Fixed to randomly generate fileReader id to avoid duplication.

--- a/packages/app/src/components/fileReader/index.tsx
+++ b/packages/app/src/components/fileReader/index.tsx
@@ -6,7 +6,7 @@ export type Props = {
 } & Pick<React.InputHTMLAttributes<HTMLInputElement>, 'accept'>;
 const _FileReader: React.FC<Props> = ({ accept, onChange }) => {
   const id = useMemo(() => {
-    return `fileReader-${Date.now()}`;
+    return `fileReader-${Math.random()}`;
   }, []);
 
   const [file, setFile] = useState<File | null>(null);


### PR DESCRIPTION
## Summary

Fixed a bug that could cause different FileReaders to be selected when using multiple FileReaders.

The cause of this bug is that the same id could be assigned to adjacent FileReaders due to the use of `Date.now()` for id generation.

### Before
![before](https://github.com/cam-inc/viron/assets/48080530/2bb2b833-0fd8-452b-ab95-3bc1144dc6c1)

### After
![after](https://github.com/cam-inc/viron/assets/48080530/e07123ad-b4f0-4eee-967a-02f4bc9f35f1)

## Related PullRequest

https://github.com/cam-inc/viron/pull/755

## issue
https://github.com/cam-inc/viron/issues/779