### PR TITLE
feat: add mode prop to determine how to opening the OAuth endpoint ✨

### DIFF
--- a/.changeset/fast-apples-switch.md
+++ b/.changeset/fast-apples-switch.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+Add a mode prop to AuthConfig to determine how to opening the OAuth endpoint.

--- a/packages/app/src/types/index.ts
+++ b/packages/app/src/types/index.ts
@@ -57,6 +57,7 @@ export type AuthConfig = {
   type: 'email' | 'oauth' | 'oauthcallback' | 'signout';
   provider: 'viron' | 'google' | 'signout';
   operationId: OperationId;
+  mode?: 'navigate' | 'cors';
   defaultParametersValue?: RequestParametersValue;
   defaultRequestBodyValue?: RequestRequestBodyValue;
 };


### PR DESCRIPTION
## Summary

Provide options for future 3pcd support where navigation would necessarily occur at present.

## Reference(s)

https://github.com/cam-inc/viron/pull/829

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
