### PR TITLE
feat: handle mode value to avoid signin error caused by 3pcd ✨

### DIFF
--- a/packages/app/src/errors/index.ts
+++ b/packages/app/src/errors/index.ts
@@ -96,6 +96,11 @@ export class EndpointExportError extends EndpointError {
   name = 'Endpoint Export Error';
 }
 
+export class EndpointOAuthIllegalResponseError extends EndpointError {
+  code = '#endpointOAuthIllegalResponse';
+  name = 'Endpoint OAuth Illegal Response Error';
+}
+
 export class EndpointGroupError extends BaseError {
   code = '#endpointGroup';
   name = 'Endpoint Group Error';

--- a/packages/app/src/hooks/endpoint.ts
+++ b/packages/app/src/hooks/endpoint.ts
@@ -57,6 +57,7 @@ import {
   constructRequestInit,
   constructRequestPayloads,
 } from '~/utils/oas';
+import { extractAuthorizationUrl } from '~/utils/oas/oauth';
 
 export type UseEndpointReturn = {
   list: Endpoint[];
@@ -535,7 +536,29 @@ export const useEndpoint = (): UseEndpointReturn => {
       );
       try {
         set(KEY.OAUTH_ENDPOINT_ID, endpoint.id);
-        globalThis.location.href = requestInfo.toString();
+
+        if (authConfig.mode !== 'cors') {
+          globalThis.location.href = requestInfo.toString();
+        } else {
+          const requestInit = constructRequestInit(request, requestPayloads);
+          const [response, responseError] = await promiseErrorHandler(
+            globalThis.fetch(requestInfo, requestInit)
+          );
+          if (!!responseError) {
+            return {
+              error: new NetworkError(responseError.message),
+            };
+          }
+          if (!response.ok) {
+            return {
+              error: await getHTTPError(response),
+            };
+          }
+          globalThis.location.href = extractAuthorizationUrl(
+            request.operation.responses,
+            await response.json()
+          );
+        }
       } catch (e: unknown) {
         remove(KEY.OAUTH_ENDPOINT_ID);
         let message = '';

--- a/packages/app/src/utils/oas/oauth.ts
+++ b/packages/app/src/utils/oas/oauth.ts
@@ -1,0 +1,20 @@
+import { Responses } from '~/types/oas';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const extractAuthorizationUrl = (responses: Responses, json: any) => {
+  const response = responses['200'];
+  if (!response || !response.content?.['application/json']) {
+    return null;
+  }
+  const schema = response.content['application/json'].schema;
+  if (!schema.properties) {
+    return null;
+  }
+  const uriKey = Object.keys(schema.properties).find((key) => {
+    const property = schema.properties?.[key];
+    return property?.type === 'string' && property.format === 'uri';
+  });
+  if (uriKey) {
+    return json[uriKey];
+  }
+};


### PR DESCRIPTION
## Summary

Due to third-party cookie blocking (3PCB), some users are currently experiencing failures in the OAuth sign-in flow. 

To mitigate this, we have implemented a pattern that allows the authentication URL to be obtained within the Viron domain, ensuring the state is treated as a partitoned cookie.

## Checklist
- [ ] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
