### PR TITLE
build: update Node version of local-example 🛠

### DIFF
--- a/Dockerfile.example-nodejs
+++ b/Dockerfile.example-nodejs
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:22
 
 RUN mkdir -p /viron/example/nodejs
 RUN mkdir -p /viron/packages/nodejs


### PR DESCRIPTION
## Summary

The base image for the example Dockerfile has been updated from Node.js version 16 to version 22.

A changeset file is not needed for this PR as this change will only affect local developers. 
The actual demo server uses the Dockerfile located in the example/nodejs directory.

## Reference(s)

N/A

## Checklist
- [ ] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included

