### PR TITLE
fix: loadPolicy fails if casbin data contains a comma

### DIFF
--- a/packages/golang/domains/adminroles.go
+++ b/packages/golang/domains/adminroles.go
@@ -480,16 +480,16 @@ func ValidateRoleAndPermissions(roleID string, permissions []*AdminRolePermissio
 	// casbinのpolicyに "," が存在すると、policyをloadする際に不具合が出る
 	if roleID != "" {
 		if existsCommas(roleID) {
-			return errors.Initialize(http.StatusInternalServerError, "role id cannot contain commas.")
+			return errors.Initialize(http.StatusBadRequest, "role id cannot contain commas.")
 		}
 	}
 	for _, policy := range permissions {
 		_policy := *policy
 		if existsCommas(_policy.ResourceID) {
-			return errors.Initialize(http.StatusInternalServerError, "policy resource id cannot contain commas.")
+			return errors.Initialize(http.StatusBadRequest, "policy resource id cannot contain commas.")
 		}
 		if existsCommas(_policy.Permission) {
-			return errors.Initialize(http.StatusInternalServerError, "policy permission cannot contain commas.")
+			return errors.Initialize(http.StatusBadRequest, "policy permission cannot contain commas.")
 		}
 	}
 	return nil

--- a/packages/golang/domains/adminroles_test.go
+++ b/packages/golang/domains/adminroles_test.go
@@ -1,5 +1,77 @@
 package domains
 
+import (
+	"github.com/cam-inc/viron/packages/golang/errors"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
 func setUpRole() {
 	NewFile("./test_casbin")
+}
+
+func TestValidateRoleAndPermissions(t *testing.T) {
+	tests := []struct {
+		Title       string
+		RoleId      string
+		Permissions []*AdminRolePermission
+		Expected    bool
+		Err         *errors.VironError
+	}{
+		{
+			Title:  "Role id with commas.",
+			RoleId: "role_00001_,",
+			Permissions: []*AdminRolePermission{
+				{
+					ResourceID: "resource_00001",
+					Permission: "read",
+				},
+			},
+			Err: errors.Initialize(http.StatusInternalServerError, "role id cannot contain commas."),
+		},
+		{
+			Title:  "Resource id with commas.",
+			RoleId: "role_00002",
+			Permissions: []*AdminRolePermission{
+				{
+					ResourceID: "resource_00002_,",
+					Permission: "read",
+				},
+			},
+			Err: errors.Initialize(http.StatusInternalServerError, "policy resource id cannot contain commas."),
+		},
+		{
+			Title:  "Permission with commas.",
+			RoleId: "role_00003",
+			Permissions: []*AdminRolePermission{
+				{
+					ResourceID: "resource_00003",
+					Permission: "read_,",
+				},
+			},
+			Err: errors.Initialize(http.StatusInternalServerError, "policy permission cannot contain commas."),
+		},
+		{
+			Title:  "No commas.",
+			RoleId: "role_00004",
+			Permissions: []*AdminRolePermission{
+				{
+					ResourceID: "resource_00004",
+					Permission: "read",
+				},
+			},
+			Err: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Title, func(t *testing.T) {
+			if err := ValidateRoleAndPermissions(tt.RoleId, tt.Permissions); err != nil {
+				assert.EqualError(t, err, tt.Err.Error())
+			} else {
+				assert.Equal(t, tt.Err, err)
+			}
+		})
+	}
 }

--- a/packages/golang/domains/adminroles_test.go
+++ b/packages/golang/domains/adminroles_test.go
@@ -28,7 +28,7 @@ func TestValidateRoleAndPermissions(t *testing.T) {
 					Permission: "read",
 				},
 			},
-			Err: errors.Initialize(http.StatusInternalServerError, "role id cannot contain commas."),
+			Err: errors.Initialize(http.StatusBadRequest, "role id cannot contain commas."),
 		},
 		{
 			Title:  "Resource id with commas.",
@@ -39,7 +39,7 @@ func TestValidateRoleAndPermissions(t *testing.T) {
 					Permission: "read",
 				},
 			},
-			Err: errors.Initialize(http.StatusInternalServerError, "policy resource id cannot contain commas."),
+			Err: errors.Initialize(http.StatusBadRequest, "policy resource id cannot contain commas."),
 		},
 		{
 			Title:  "Permission with commas.",
@@ -50,7 +50,7 @@ func TestValidateRoleAndPermissions(t *testing.T) {
 					Permission: "read_,",
 				},
 			},
-			Err: errors.Initialize(http.StatusInternalServerError, "policy permission cannot contain commas."),
+			Err: errors.Initialize(http.StatusBadRequest, "policy permission cannot contain commas."),
 		},
 		{
 			Title:  "No commas.",


### PR DESCRIPTION
## Summary

loadPolicy fails if casbin data contains a comma

## Reference(s)

N/A


## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included