### PR TITLE
fix: missing build step handling for when Turborepo is used 🐛

### DIFF
--- a/example/nodejs/Dockerfile
+++ b/example/nodejs/Dockerfile
@@ -8,11 +8,11 @@ WORKDIR /app
 # package build
 COPY --chown=node:node package.json ./
 COPY --chown=node:node package-lock.json ./
+COPY --chown=node:node turbo.json ./
 COPY --chown=node:node example/nodejs ./example/nodejs
 COPY --chown=node:node packages/nodejs ./packages/nodejs
 COPY --chown=node:node packages/linter ./packages/linter
-RUN npm install && npm cache verify
-RUN npm run build
+RUN npm install && npm cache verify && npm run build -- --filter=@viron/example-nodejs
 
 WORKDIR /app/example/nodejs
 


### PR DESCRIPTION
## Summary

The Docker image build for the example package failed because Turborepo was not taken into consideration.