### PR TITLE
feat: support CHIPS to resolve 3pcd ✨

### DIFF
--- a/.changeset/little-feet-remember.md
+++ b/.changeset/little-feet-remember.md
@@ -1,0 +1,7 @@
+---
+"@viron/lib": minor
+"@viron/app": minor
+---
+
+Design a new sign-in flow in preparation for the upcoming deprecation of third-party cookies.
+

--- a/example/nodejs/src/controllers/auth.ts
+++ b/example/nodejs/src/controllers/auth.ts
@@ -23,11 +23,16 @@ export const signout = async (context: RouteContext): Promise<void> => {
 export const signinEmail = async (context: RouteContext): Promise<void> => {
   const { email, password } = context.requestBody;
   const token = await domainsAuth.signinEmail(context.req, email, password);
-  context.res.setHeader(
-    HTTP_HEADER.SET_COOKIE,
-    genAuthorizationCookie(token, { maxAge: ctx.config.auth.jwt.expirationSec })
-  );
-  context.res.status(204).end();
+  context.res
+    .header(
+      HTTP_HEADER.SET_COOKIE,
+      genAuthorizationCookie(token, {
+        maxAge: ctx.config.auth.jwt.expirationSec,
+        partitioned: true,
+      })
+    )
+    .status(204)
+    .end();
 };
 
 // OIDCの認証画面 URL を返却
@@ -58,13 +63,9 @@ export const oidcAuthorization = async (
     genOidcCodeVerifierCookie(codeVerifier, { partitioned: true }),
   ];
 
-  context.res
-    .status(200)
-    .set(HTTP_HEADER.SET_COOKIE, cookies)
-    .set(HTTP_HEADER.LOCATION, authorizationUrl)
-    .json({
-      authorizationUrl,
-    });
+  context.res.header(HTTP_HEADER.SET_COOKIE, cookies).json({
+    authorizationUrl,
+  });
 };
 
 // OIDCのコールバック
@@ -92,7 +93,7 @@ export const oidcCallback = async (context: RouteContext): Promise<void> => {
     ctx.config.auth.oidc,
     ctx.config.auth.multipleAuthUser
   );
-  context.res.setHeader(
+  context.res.header(
     HTTP_HEADER.SET_COOKIE,
     genAuthorizationCookie(token, {
       maxAge: ctx.config.auth.jwt.expirationSec,
@@ -118,8 +119,7 @@ export const oauth2GoogleAuthorization = async (
     ctx.config.auth.googleOAuth2
   );
   context.res
-    .status(200)
-    .set(
+    .header(
       HTTP_HEADER.SET_COOKIE,
       genOAuthStateCookie(state, { partitioned: true })
     )
@@ -146,12 +146,14 @@ export const oauth2GoogleCallback = async (
     ctx.config.auth.googleOAuth2,
     ctx.config.auth.multipleAuthUser
   );
-  context.res.setHeader(
-    HTTP_HEADER.SET_COOKIE,
-    genAuthorizationCookie(token, {
-      maxAge: ctx.config.auth.jwt.expirationSec,
-      partitioned: true,
-    })
-  );
-  context.res.status(204).end();
+  context.res
+    .header(
+      HTTP_HEADER.SET_COOKIE,
+      genAuthorizationCookie(token, {
+        maxAge: ctx.config.auth.jwt.expirationSec,
+        partitioned: true,
+      })
+    )
+    .status(204)
+    .end();
 };

--- a/example/nodejs/src/controllers/authconfigs.ts
+++ b/example/nodejs/src/controllers/authconfigs.ts
@@ -1,6 +1,7 @@
 import {
   domainsAuthConfig,
   API_METHOD,
+  AUTH_CONFIG_MODE,
   AUTH_CONFIG_TYPE,
   AUTH_CONFIG_PROVIDER,
   EMAIL_SIGNIN_PATH,
@@ -49,6 +50,7 @@ export const listVironAuthconfigs = async (
             defaultRequestBodyValue: {
               clientId: ctx.config.auth.googleOAuth2.clientId,
             },
+            mode: AUTH_CONFIG_MODE.CORS,
           },
           {
             provider: AUTH_CONFIG_PROVIDER.GOOGLE,
@@ -78,6 +80,7 @@ export const listVironAuthconfigs = async (
             defaultRequestBodyValue: {
               clientId: ctx.config.auth.oidc.clientId,
             },
+            mode: AUTH_CONFIG_MODE.CORS,
           },
           {
             provider: AUTH_CONFIG_PROVIDER.OIDC,
@@ -92,6 +95,7 @@ export const listVironAuthconfigs = async (
         ]
       : []),
   ];
+
   const result = genAuthConfigs(
     authConfigDefinitions,
     context.req._context.apiDefinition

--- a/packages/app/src/hooks/endpoint.ts
+++ b/packages/app/src/hooks/endpoint.ts
@@ -117,7 +117,7 @@ export type UseEndpointReturn = {
         defaultValues: RequestValue;
         execute: (
           requestValue: RequestValue
-        ) => Promise<{ error: BaseError } | { error: null }>;
+        ) => Promise<{ error: BaseError | null }>;
       };
   prepareSigninOAuth: (
     endpoint: Endpoint,
@@ -133,7 +133,7 @@ export type UseEndpointReturn = {
         defaultValues: RequestValue;
         execute: (
           requestValue: RequestValue
-        ) => Promise<{ error: BaseError } | { error: null }>;
+        ) => Promise<{ error: BaseError | null }>;
       };
   prepareSigninOAuthCallback: (
     endpoint: Endpoint,
@@ -574,7 +574,16 @@ export const useEndpoint = (): UseEndpointReturn => {
         );
         try {
           set(KEY.OIDC_ENDPOINT_ID, endpoint.id);
-          globalThis.location.href = requestInfo.toString();
+          let href: string;
+          if (authConfig.mode === 'cors') {
+            const { authorizationUrl } = await globalThis
+              .fetch(requestInfo, { mode: 'cors', credentials: 'include' })
+              .then((res) => res.json());
+            href = authorizationUrl;
+          } else {
+            href = requestInfo.toString();
+          }
+          globalThis.location.href = href;
         } catch (e: unknown) {
           remove(KEY.OIDC_ENDPOINT_ID);
           let message = '';
@@ -640,6 +649,7 @@ export const useEndpoint = (): UseEndpointReturn => {
         request.operation,
         requestValue
       );
+
       const requestInfo = constructRequestInfo(
         endpoint,
         authentication.oas,
@@ -648,7 +658,16 @@ export const useEndpoint = (): UseEndpointReturn => {
       );
       try {
         set(KEY.OAUTH_ENDPOINT_ID, endpoint.id);
-        globalThis.location.href = requestInfo.toString();
+        let href: string;
+        if (authConfig.mode === 'cors') {
+          const { authorizationUrl } = await globalThis
+            .fetch(requestInfo, { mode: 'cors', credentials: 'include' })
+            .then((res) => res.json());
+          href = authorizationUrl;
+        } else {
+          href = requestInfo.toString();
+        }
+        globalThis.location.href = href;
       } catch (e: unknown) {
         remove(KEY.OAUTH_ENDPOINT_ID);
         let message = '';

--- a/packages/app/src/hooks/endpoint.ts
+++ b/packages/app/src/hooks/endpoint.ts
@@ -576,9 +576,19 @@ export const useEndpoint = (): UseEndpointReturn => {
           set(KEY.OIDC_ENDPOINT_ID, endpoint.id);
           let href: string;
           if (authConfig.mode === 'cors') {
-            const { authorizationUrl } = await globalThis
-              .fetch(requestInfo, { mode: 'cors', credentials: 'include' })
-              .then((res) => res.json());
+            const [response, responseError] = await promiseErrorHandler(
+              globalThis.fetch(requestInfo, {
+                mode: 'cors',
+                credentials: 'include',
+              })
+            );
+            // Could not establish a network connection to the endpoint.
+            if (responseError) {
+              return {
+                error: new NetworkError(responseError.message),
+              };
+            }
+            const { authorizationUrl } = await response.json();
             href = authorizationUrl;
           } else {
             href = requestInfo.toString();
@@ -660,9 +670,19 @@ export const useEndpoint = (): UseEndpointReturn => {
         set(KEY.OAUTH_ENDPOINT_ID, endpoint.id);
         let href: string;
         if (authConfig.mode === 'cors') {
-          const { authorizationUrl } = await globalThis
-            .fetch(requestInfo, { mode: 'cors', credentials: 'include' })
-            .then((res) => res.json());
+          const [response, responseError] = await promiseErrorHandler(
+            globalThis.fetch(requestInfo, {
+              mode: 'cors',
+              credentials: 'include',
+            })
+          );
+          // Could not establish a network connection to the endpoint.
+          if (responseError) {
+            return {
+              error: new NetworkError(responseError.message),
+            };
+          }
+          const { authorizationUrl } = await response.json();
           href = authorizationUrl;
         } else {
           href = requestInfo.toString();

--- a/packages/nodejs/src/constants.ts
+++ b/packages/nodejs/src/constants.ts
@@ -15,6 +15,7 @@ export const AUTH_CONFIG_TYPE = {
   OIDC_CALLBACK: 'oidccallback',
   SIGNOUT: 'signout',
 } as const;
+
 export type AuthConfigType =
   (typeof AUTH_CONFIG_TYPE)[keyof typeof AUTH_CONFIG_TYPE];
 
@@ -24,8 +25,17 @@ export const AUTH_CONFIG_PROVIDER = {
   OIDC: 'oidc',
   SIGNOUT: 'signout',
 } as const;
+
 export type AuthConfigProvider =
   (typeof AUTH_CONFIG_PROVIDER)[keyof typeof AUTH_CONFIG_PROVIDER];
+
+export const AUTH_CONFIG_MODE = {
+  NAVIGATE: 'navigate',
+  CORS: 'cors',
+} as const;
+
+export type AuthConfigMode =
+  (typeof AUTH_CONFIG_MODE)[keyof typeof AUTH_CONFIG_MODE];
 
 export const STORE_TYPE = {
   MYSQL: 'mysql',

--- a/packages/nodejs/src/domains/authconfig.ts
+++ b/packages/nodejs/src/domains/authconfig.ts
@@ -1,4 +1,5 @@
 import {
+  AuthConfigMode,
   AuthConfigProvider,
   AuthConfigType,
   ApiMethod,
@@ -17,6 +18,7 @@ export interface AuthConfig {
   defaultParametersValue?: Record<string, any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   defaultRequestBodyValue?: any;
+  mode?: AuthConfigMode;
 }
 
 export type AuthConfigs = AuthConfig[];
@@ -35,6 +37,7 @@ export interface AuthConfigDefinition {
   defaultParametersValue?: Record<string, any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   defaultRequestBodyValue?: any;
+  mode?: AuthConfigMode;
 }
 
 export type AuthConfigDefinitions = AuthConfigDefinition[];
@@ -47,7 +50,8 @@ const genAuthConfig = (
   oas: VironOpenAPIObject,
   defaultParametersValue?: Record<string, unknown>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  defaultRequestBodyValue?: any
+  defaultRequestBodyValue?: any,
+  mode?: AuthConfigMode
 ): AuthConfig => {
   const operationObject = findOperation(path, method, oas);
   if (!operationObject) {
@@ -65,6 +69,7 @@ const genAuthConfig = (
       ...operationObject[OAS_X_AUTHCONFIG_DEFAULT_REQUESTBODY],
       ...defaultRequestBodyValue,
     },
+    mode,
   };
 };
 
@@ -81,6 +86,7 @@ export const genAuthConfigs = (
         path,
         defaultParametersValue,
         defaultRequestBodyValue,
+        mode,
       } = def;
       ret.list.push(
         genAuthConfig(
@@ -90,7 +96,8 @@ export const genAuthConfigs = (
           path,
           oas,
           defaultParametersValue,
-          defaultRequestBodyValue
+          defaultRequestBodyValue,
+          mode
         )
       );
       ret.paths[path] = ret.paths[path] ?? {};

--- a/packages/nodejs/src/helpers/cookies.ts
+++ b/packages/nodejs/src/helpers/cookies.ts
@@ -14,22 +14,11 @@ export const genCookie = (
   options?: CookieSerializeOptions
 ): string => {
   const opts = Object.assign({}, options);
-  if (opts.httpOnly === undefined) {
-    opts.httpOnly = true;
-  }
-  if (!opts.path) {
-    opts.path = '/';
-  }
-  if (opts.secure === undefined) {
-    opts.secure = true;
-  }
-  if (!opts.sameSite) {
-    opts.sameSite = 'none';
-  }
-  // TODO: Set to true by default after all 3pcd support is complete
-  // if (opts.partitioned === undefined) {
-  //   opts.partitioned = true;
-  // }
+  opts.httpOnly ??= true;
+  opts.path ??= '/';
+  opts.secure ??= true;
+  opts.sameSite ??= 'none';
+  opts.partitioned ??= false;
   return serialize(key, value, opts);
 };
 

--- a/packages/nodejs/src/openapi/auth.yaml
+++ b/packages/nodejs/src/openapi/auth.yaml
@@ -16,7 +16,7 @@ paths:
       summary: signout of viron
       description: Vironからログアウトする
       responses:
-        204:
+        '204':
           description: OK
 
   /email/signin:
@@ -33,7 +33,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SigninEmailPayload'
       responses:
-        204:
+        '204':
           description: No Content
 
   /oidc/authorization:
@@ -47,7 +47,17 @@ paths:
         - $ref: '#/components/parameters/RedirectUriQueryParam'
         - $ref: '#/components/parameters/ClientIdQueryParam'
       responses:
-        301:
+        '200':
+          description: authorization url を返却し、アプリケーション側にリダイレクトを促す
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  authorizationUrl:
+                    type: string
+                    format: uri
+        '301':
           description: Redirect to OIDC Authorization URL.
       x-authconfig-default-parameters:
         redirectUri: '${oidcRedirectURI}'
@@ -66,7 +76,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OidcCallbackPayload'
       responses:
-        204:
+        '204':
           description: No Content.
       x-authconfig-default-requestBody:
         redirectUri: '${oidcRedirectURI}'
@@ -82,7 +92,17 @@ paths:
         - $ref: '#/components/parameters/RedirectUriQueryParam'
         - $ref: '#/components/parameters/ClientIdQueryParam'
       responses:
-        301:
+        '200':
+          description: authorization url を返却し、アプリケーション側にリダイレクトを促す
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  authorizationUrl:
+                    type: string
+                    format: uri
+        '301':
           description: Redirect to Google OAuth URL.
       x-authconfig-default-parameters:
         redirectUri: '${oauthRedirectURI}'
@@ -101,7 +121,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OAuth2GoogleCallbackPayload'
       responses:
-        204:
+        '204':
           description: No Content.
       x-authconfig-default-requestBody:
         redirectUri: '${oauthRedirectURI}'

--- a/packages/nodejs/src/openapi/auth.yaml
+++ b/packages/nodejs/src/openapi/auth.yaml
@@ -42,7 +42,7 @@ paths:
       tags:
         - auth
       summary: redirect to oidc idp authorization
-      description: OIDCのidp 認証画面へリダイレクトする
+      description: OIDCの idp 認証画面へリダイレクトするための情報、ステータスを返却する
       parameters:
         - $ref: '#/components/parameters/RedirectUriQueryParam'
         - $ref: '#/components/parameters/ClientIdQueryParam'
@@ -52,11 +52,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  authorizationUrl:
-                    type: string
-                    format: uri
+                $ref: '#/components/schemas/AuthenticationRedirect'
         '301':
           description: Redirect to OIDC Authorization URL.
       x-authconfig-default-parameters:
@@ -87,7 +83,7 @@ paths:
       tags:
         - auth
       summary: redirect to google oauth
-      description: GoogleのOAuth認可画面へリダイレクトする
+      description: Google の OAuth 認証画面へリダイレクトするための情報、ステータスを返却する
       parameters:
         - $ref: '#/components/parameters/RedirectUriQueryParam'
         - $ref: '#/components/parameters/ClientIdQueryParam'
@@ -97,11 +93,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  authorizationUrl:
-                    type: string
-                    format: uri
+                $ref: '#/components/schemas/AuthenticationRedirect'
         '301':
           description: Redirect to Google OAuth URL.
       x-authconfig-default-parameters:
@@ -206,3 +198,10 @@ components:
         - state
         - redirectUri
         - clientId
+
+    AuthenticationRedirect:
+      type: object
+      properties:
+        authorizationUrl:
+          type: string
+          format: uri

--- a/packages/nodejs/src/openapi/auth.yaml
+++ b/packages/nodejs/src/openapi/auth.yaml
@@ -52,7 +52,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthenticationRedirect'
+                $ref: '#/components/schemas/OidcAuthorizationUrl'
         '301':
           description: Redirect to OIDC Authorization URL.
       x-authconfig-default-parameters:
@@ -93,7 +93,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AuthenticationRedirect'
+                $ref: '#/components/schemas/GoogleAuthorizationUrl'
         '301':
           description: Redirect to Google OAuth URL.
       x-authconfig-default-parameters:
@@ -199,9 +199,20 @@ components:
         - redirectUri
         - clientId
 
-    AuthenticationRedirect:
+    GoogleAuthorizationUrl:
       type: object
       properties:
         authorizationUrl:
           type: string
           format: uri
+      required:
+        - authorizationUrl
+
+    OidcAuthorizationUrl:
+      type: object
+      properties:
+        authorizationUrl:
+          type: string
+          format: uri
+      required:
+        - authorizationUrl

--- a/packages/nodejs/src/openapi/authconfigs.yaml
+++ b/packages/nodejs/src/openapi/authconfigs.yaml
@@ -16,7 +16,7 @@ paths:
       summary: list auth configs
       description: 認証設定を取得する
       responses:
-        200:
+        '200':
           description: OK
           content:
             application/json:
@@ -68,6 +68,13 @@ components:
           description: クライアントからリクエストする際のリクエストボディ
           type: object
           properties: {}
+        mode:
+          description: クライアントが認証を開始する方法を指定する (cors または navigate)
+          type: string
+          enum:
+            - cors
+            - navigate
+          example: cors
       required:
         - provider
         - type

--- a/packages/website/docs/04-Advanced-Guides/authentication.md
+++ b/packages/website/docs/04-Advanced-Guides/authentication.md
@@ -51,9 +51,10 @@ There are four types of authentication: `email`, `oauth`, `oauthcallback`, `oidc
 ```
 
 :::tip
-The recommended value for mode is generally `cors`. This ensures that cookies are issued with the Partitioned attribute, enabling secure authentication across different domains.
+The recommended value for mode is generally `cors`. When cors is set, the endpoint is responsible for adding the `Partitioned` attribute to all issued cookies in order to enable third-party cookies across different domains.
 
-However, this may not apply if you're self-hosting Viron and the endpoints are not cross-origin.
+This does not apply if you're self-hosting Viron and the endpoints are not cross-origin.
+:::
 
 ### `email`
 

--- a/packages/website/docs/04-Advanced-Guides/authentication.md
+++ b/packages/website/docs/04-Advanced-Guides/authentication.md
@@ -43,11 +43,17 @@ There are four types of authentication: `email`, `oauth`, `oauthcallback`, `oidc
 {
   "type": "email" | "oauth" | "oauthcallback" | "oidc" | "oidccallback" | "signout";
   "provider": string;
-  "operatioId": string; // Used to determine how to send a request.
+  "operationId": string; // Used to determine how to send a request.
+  "mode"?: 'navigate' | 'cors'; // Used to determine how to open the endpoint. Applicable only when the type is 'oauth' or 'oidc'.
   "defaultParametersValue"?: any;
   "defaultRequestBodyValue"?: any;
 }
 ```
+
+:::tip
+The recommended value for mode is generally `cors`. This ensures that cookies are issued with the Partitioned attribute, enabling secure authentication across different domains.
+
+However, this may not apply if you're self-hosting Viron and the endpoints are not cross-origin.
 
 ### `email`
 
@@ -109,6 +115,7 @@ Those types of authentication are for [the Authorization Code Grant of the OAuth
     {
       "type": "oauth",
       "operationId": "signinOAuth",
+      "mode": "cors",
       "defaultParametersValue": {
         "redirectUri": "${oauthRedirectURI}" // An environmental variable
       }
@@ -185,6 +192,7 @@ Those types of authentication are for [the Authorization Code Flow of the OpenID
     {
       "type": "oidc",
       "operationId": "signinOidc",
+      "mode": "cors",
       "defaultParametersValue": {
         "redirectUri": "${oidcRedirectURI}" // An environmental variable
       }

--- a/packages/website/docs/04-Advanced-Guides/authentication.md
+++ b/packages/website/docs/04-Advanced-Guides/authentication.md
@@ -54,6 +54,8 @@ There are four types of authentication: `email`, `oauth`, `oauthcallback`, `oidc
 The recommended value for mode is generally `cors`. When cors is set, the endpoint is responsible for adding the `Partitioned` attribute to all issued cookies in order to enable third-party cookies across different domains.
 
 This does not apply if you're self-hosting Viron and the endpoints are not cross-origin.
+
+For backward compatibility, if mode is not specified, it behaves the same as navigate.
 :::
 
 ### `email`
@@ -151,8 +153,24 @@ Those types of authentication are for [the Authorization Code Grant of the OAuth
             }
           ],
           "responses": {
+            "200": {
+              "description": "Returns the authorization URL if mode is cors.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "authorizationUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "301": {
-              "description": "Redirect to the authorization endpoint."
+-             "description": "Redirect to the authorization endpoint if mode is navigate."
             }
           }
         }
@@ -228,8 +246,24 @@ Those types of authentication are for [the Authorization Code Flow of the OpenID
             }
           ],
           "responses": {
+            "200": {
+              "description": "Returns the authorization URL if mode is cors.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "authorizationUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "301": {
-              "description": "Redirect to the authorization endpoint."
+-             "description": "Redirect to the authorization endpoint if mode is navigate."
             }
           }
         }

--- a/packages/website/i18n/ja/docusaurus-plugin-content-docs/current/04-Advanced-Guides/authentication.md
+++ b/packages/website/i18n/ja/docusaurus-plugin-content-docs/current/04-Advanced-Guides/authentication.md
@@ -43,11 +43,17 @@ There are four types of authentication: `email`, `oauth`, `oauthcallback`, `oidc
 {
   "type": "email" | "oauth" | "oauthcallback" | "oidc" | "oidccallback" | "signout";
   "provider": string;
-  "operatioId": string; // Used to determine how to send a request.
+  "operationId": string; // Used to determine how to send a request.
+  "mode"?: 'navigate' | 'cors'; // Used to determine how to open the endpoint. Applicable only when the type is 'oauth' or 'oidc'.
   "defaultParametersValue"?: any;
   "defaultRequestBodyValue"?: any;
 }
 ```
+
+:::tip
+mode は基本的に `cors` が望ましいでしょう。発行される Cookie に `Partitioned` 属性が付与され、異なるドメイン間での安全な認証が可能です。
+
+Viron をセルフホスティングしており、エンドポイント間が CORS にならない場合は、その限りではありません。
 
 ### `email`
 
@@ -109,6 +115,7 @@ Those types of authentication are for [the Authorization Code Grant of the OAuth
     {
       "type": "oauth",
       "operationId": "signinOAuth",
+      "mode": "cors",
       "defaultParametersValue": {
         "redirectUri": "${oauthRedirectURI}" // An environmental variable
       }
@@ -184,6 +191,7 @@ Those types of authentication are for [the Authorization Code Flow of the OpenID
   "list": [
     {
       "type": "oidc",
+      "mode": "cors",
       "operationId": "signinOidc",
       "defaultParametersValue": {
         "redirectUri": "${oidcRedirectURI}" // An environmental variable

--- a/packages/website/i18n/ja/docusaurus-plugin-content-docs/current/04-Advanced-Guides/authentication.md
+++ b/packages/website/i18n/ja/docusaurus-plugin-content-docs/current/04-Advanced-Guides/authentication.md
@@ -51,9 +51,11 @@ There are four types of authentication: `email`, `oauth`, `oauthcallback`, `oidc
 ```
 
 :::tip
-mode は基本的に `cors` が望ましいでしょう。発行される Cookie に `Partitioned` 属性が付与され、異なるドメイン間での安全な認証が可能です。
+mode は基本的に `cors` が望ましいでしょう。cors を設定した場合、異なるドメイン間でのサードパーティクッキーを有効にするため、エンドポイントは発行する各種 Cookie に `Partitioned` 属性を付与する責任を持ちます。
 
 Viron をセルフホスティングしており、エンドポイント間が CORS にならない場合は、その限りではありません。
+
+:::
 
 ### `email`
 

--- a/packages/website/i18n/ja/docusaurus-plugin-content-docs/current/04-Advanced-Guides/authentication.md
+++ b/packages/website/i18n/ja/docusaurus-plugin-content-docs/current/04-Advanced-Guides/authentication.md
@@ -55,6 +55,7 @@ mode は基本的に `cors` が望ましいでしょう。cors を設定した�
 
 Viron をセルフホスティングしており、エンドポイント間が CORS にならない場合は、その限りではありません。
 
+mode は後方互換性のため、未設定の場合に `navigate` と同じ振る舞いをします。
 :::
 
 ### `email`
@@ -152,8 +153,24 @@ Those types of authentication are for [the Authorization Code Grant of the OAuth
             }
           ],
           "responses": {
+            "200": {
+              "description": "Returns the authorization URL if mode is cors.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "authorizationUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "301": {
-              "description": "Redirect to the authorization endpoint."
+-             "description": "Redirect to the authorization endpoint if mode is navigate."
             }
           }
         }
@@ -193,8 +210,8 @@ Those types of authentication are for [the Authorization Code Flow of the OpenID
   "list": [
     {
       "type": "oidc",
-      "mode": "cors",
       "operationId": "signinOidc",
+      "mode": "cors",
       "defaultParametersValue": {
         "redirectUri": "${oidcRedirectURI}" // An environmental variable
       }
@@ -229,8 +246,24 @@ Those types of authentication are for [the Authorization Code Flow of the OpenID
             }
           ],
           "responses": {
+            "200": {
+              "description": "Returns the authorization URL if mode is cors.",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "authorizationUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "301": {
-              "description": "Redirect to the authorization endpoint."
+-             "description": "Redirect to the authorization endpoint if mode is navigate."
             }
           }
         }


### PR DESCRIPTION
## Summary

In preparation for the future deprecation of third-party cookies, we've designed a new sign-in flow. 

The new AuthConfig can return a mode property, which indicates whether the front-end should trigger a top-level navigation or initiate the sign-in flow via a Fetch request.

The Viron endpoint also needs to support sign-in via Fetch by returning the URL in the response body.

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
