### PR TITLE
feat: use latest nodejs to build and deploy app ✨

### DIFF
--- a/codepipeline/app-buildspec.yml
+++ b/codepipeline/app-buildspec.yml
@@ -4,7 +4,7 @@ run-as: root
 phases:
   install:
     runtime-versions:
-      nodejs: 18
+      nodejs: latest
 
   pre_build:
     commands:

--- a/codepipeline/app-deployspec.yml
+++ b/codepipeline/app-deployspec.yml
@@ -4,12 +4,12 @@ run-as: root
 phases:
   install:
     runtime-versions:
-      nodejs: 18
+      nodejs: latest
     commands:
       - echo install dependencies for E2E Testing...
       - apt-get update -y
       # https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies
-      - apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb 
+      - apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
   build:
     commands:

--- a/codepipeline/snapshot-app-buildspec.yml
+++ b/codepipeline/snapshot-app-buildspec.yml
@@ -4,7 +4,7 @@ run-as: root
 phases:
   install:
     runtime-versions:
-      nodejs: 18
+      nodejs: latest
 
   pre_build:
     commands:
@@ -19,7 +19,6 @@ phases:
       - echo Building app...
       - cd $CODEBUILD_SRC_DIR/packages/app
       - npm run build:prefix
-
 
 artifacts:
   files:

--- a/codepipeline/snapshot-app-deployspec.yml
+++ b/codepipeline/snapshot-app-deployspec.yml
@@ -4,7 +4,7 @@ run-as: root
 phases:
   install:
     runtime-versions:
-      nodejs: 18
+      nodejs: latest
 
   build:
     commands:


### PR DESCRIPTION
## Summary

We've decided to use the latest version of Node.js. While this may introduce a risk of build failures, we can detect such issues since the environment is under our control.

This decision prioritizes reducing the risk of unintentionally continuing to use outdated versions.

