### PR TITLE
fix: 🐛 Fix missing initial values in admin role resourceId select boxes

### DIFF
--- a/.changeset/serious-dryers-wonder.md
+++ b/.changeset/serious-dryers-wonder.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+correct initial Enum value not reflected in UI

--- a/packages/app/src/components/schema/types/string/index.tsx
+++ b/packages/app/src/components/schema/types/string/index.tsx
@@ -124,8 +124,8 @@ const SchemaOfTypeString: React.FC<Props> = ({
 
   if (isDynamicEnumEnabled) {
     return (
-      <Select {...register(name, registerOptions)}>
-        <SelectItem value={undefined}>---</SelectItem>
+      <Select {...register(name, registerOptions)} value={data ?? ''}>
+        <SelectItem value="">---</SelectItem>
         {dynamicEnumList.map((item, idx) => (
           <SelectItem key={idx} value={item}>
             {item}
@@ -137,8 +137,8 @@ const SchemaOfTypeString: React.FC<Props> = ({
 
   if (schema.enum) {
     return (
-      <Select {...register(name, registerOptions)}>
-        <SelectItem value={undefined}>---</SelectItem>
+      <Select {...register(name, registerOptions)} value={data ?? ''}>
+        <SelectItem value="">---</SelectItem>
         {schema.enum.map((item, idx) => (
           <SelectItem key={idx} value={item}>
             {item}

--- a/packages/app/src/components/schema/types/string/index.tsx
+++ b/packages/app/src/components/schema/types/string/index.tsx
@@ -124,8 +124,8 @@ const SchemaOfTypeString: React.FC<Props> = ({
 
   if (isDynamicEnumEnabled) {
     return (
-      <Select {...register(name, registerOptions)} value={data ?? ''}>
-        <SelectItem value="">---</SelectItem>
+      <Select {...register(name, registerOptions)} value={data}>
+        <SelectItem value={undefined}>---</SelectItem>
         {dynamicEnumList.map((item, idx) => (
           <SelectItem key={idx} value={item}>
             {item}
@@ -137,8 +137,8 @@ const SchemaOfTypeString: React.FC<Props> = ({
 
   if (schema.enum) {
     return (
-      <Select {...register(name, registerOptions)} value={data ?? ''}>
-        <SelectItem value="">---</SelectItem>
+      <Select {...register(name, registerOptions)} value={data}>
+        <SelectItem value={undefined}>---</SelectItem>
         {schema.enum.map((item, idx) => (
           <SelectItem key={idx} value={item}>
             {item}


### PR DESCRIPTION
## Overview
Fixed issue where admin role resourceId values returned from server were not displayed as initial values in edit page select boxes.

## Problem
- When editing admin roles, the resourceId select boxes (both dynamic enum and regular enum) were not showing the existing values as selected
- This was caused by using undefined as default value in SelectItem components and missing explicit value property binding to current form values

## Solution
- Use `watch()` to monitor current form values for both dynamic enum and regular enum selects
- Set SelectItem value by watched value.

## Changes
- `packages/app/src/components/schema/types/string/index.tsx`: Fixed both dynamic enum and regular enum Select components

## Testing
- Verified that existing resourceId values are now properly displayed when editing admin roles
- E2E tests pass successfully

## Related
Fixes bug where server-returned resourceId values were not visible in admin role edit page Select boxes.