### PR TITLE
fix(app): use appropriate icons for navigation items on homepage

### DIFF
--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { PageProps, graphql } from 'gatsby';
-import { ExternalLinkIcon } from 'lucide-react';
+import { FileTextIcon, RocketIcon, CircleHelpIcon } from 'lucide-react';
 import React, { useCallback } from 'react';
 import Link from '@/components/link';
 import Logo from '@/components/logo';
@@ -48,17 +48,17 @@ const HomePage: React.FC<Props> = () => {
         <div className="text-xs mt-20 [&>ul]:flex [&>ul]:gap-x-4 [&>ul]:gap-y-2 [&>ul]:flex-wrap space-y-4">
           <ul>
             <NavigationListItem
-              icon={<ExternalLinkIcon />}
+              icon={<FileTextIcon />}
               label="documentation"
               to={URL.DOCUMENTATION}
             />
             <NavigationListItem
-              icon={<ExternalLinkIcon />}
+              icon={<RocketIcon />}
               label="releaseNotes"
               to={URL.RELEASE_NOTES}
             />
             <NavigationListItem
-              icon={<ExternalLinkIcon />}
+              icon={<CircleHelpIcon />}
               label="help"
               to={URL.HELP}
             />


### PR DESCRIPTION
## Changes

Updated navigation item icons on the homepage to match those used in the sidebar for consistency.

### Icon Changes:
- **Documentation**:  →  📄
- **Release Notes**:  →  🚀  
- **Help**:  →  ❓

### Reason for Change
All navigation items on the homepage were using the same , making it difficult to distinguish between different items. The sidebar already used appropriate individual icons, so we updated the homepage to use the same icons for consistency.