### PR TITLE
fix: update layout and scrolling for endpoint sub body

### DIFF
--- a/.changeset/curly-dolls-mix.md
+++ b/.changeset/curly-dolls-mix.md
@@ -1,0 +1,5 @@
+---
+"@viron/app": patch
+---
+
+Added padding to the subbody and enabled scrolling.

--- a/packages/app/src/pages/endpoints/[endpointId]/_/subBody/index.tsx
+++ b/packages/app/src/pages/endpoints/[endpointId]/_/subBody/index.tsx
@@ -25,7 +25,7 @@ const Body: React.FC<Props> = ({
   }, [selectedContentId, contents]);
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="flex flex-col">
       <Tabs value={selectedContentId} onValueChange={setSelectedContentId}>
         <TabsList>
           {contents.map((content) => (

--- a/packages/app/src/pages/endpoints/[endpointId]/index.tsx
+++ b/packages/app/src/pages/endpoints/[endpointId]/index.tsx
@@ -285,7 +285,11 @@ const EndpointPage: React.FC<Props> = ({ params }) => {
             {0 < pinnedContentIds.length && RenderSubBody && (
               <>
                 <ResizableHandle withHandle />
-                <ResizablePanel>{RenderSubBody}</ResizablePanel>
+                <ResizablePanel>
+                  <div className="mx-10 py-6 h-full overflow-y-scroll">
+                    {RenderSubBody}
+                  </div>
+                </ResizablePanel>
               </>
             )}
           </ResizablePanelGroup>


### PR DESCRIPTION
## Summary

Added padding to the subbody and enabled scrolling.

<img width="1344" height="1196" alt="subbody" src="https://github.com/user-attachments/assets/59ee945b-368d-4974-b477-f7e9a005c5d1" />

## Checklist
- [x] [changeset file(s)](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) included
