### PR TITLE
fix: ロール権限更新時にユーザーのロール割り当てがDBから削除される問題を修正

### DIFF
--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @viron/nodejs
 
+## 2.6.4
+
+### Patch Changes
+
+- Casbin custom update bug fix
+
 ## 2.6.3
 
 ### Patch Changes

--- a/packages/nodejs/__tests__/domains/adminrole.test.ts
+++ b/packages/nodejs/__tests__/domains/adminrole.test.ts
@@ -598,6 +598,61 @@ describe('domains/adminrole', () => {
         })
       );
     });
+
+    it('Preserve g-rules (user-role assignments) when updating role permissions.', async () => {
+      // Setup: Add users to the role before updating permissions
+      const userId1 = 'user1';
+      const userId2 = 'user2';
+      await casbin.addRoleForUser(userId1, 'editor');
+      await casbin.addRoleForUser(userId2, 'editor');
+
+      // Verify initial state: users have the role
+      const initialUsers = await listUsers('editor');
+      assert.deepStrictEqual(initialUsers.sort(), [userId1, userId2]);
+
+      // Update role permissions
+      const result = await updatePermissionsForRole('editor', [
+        {
+          resourceId: 'news',
+          permission: PERMISSION.READ,
+        },
+        {
+          resourceId: 'news',
+          permission: PERMISSION.WRITE,
+        },
+      ]);
+      assert.strictEqual(result, true);
+
+      // Verify p-rules are updated correctly
+      const actualPolicies = await listPolicies('editor');
+      assert.strictEqual(actualPolicies.length, 2);
+      assert(
+        actualPolicies.every((a) => {
+          if (a.resourceId !== 'news') {
+            return false;
+          }
+          return (
+            a.permission === PERMISSION.READ ||
+            a.permission === PERMISSION.WRITE
+          );
+        })
+      );
+
+      // Critical: Verify g-rules (user-role assignments) are preserved
+      const usersAfterUpdate = await listUsers('editor');
+      assert.deepStrictEqual(usersAfterUpdate.sort(), [userId1, userId2]);
+
+      // Verify users can still be identified with the role
+      const rolesForUser1 = await listRoles(userId1);
+      const rolesForUser2 = await listRoles(userId2);
+      assert.deepStrictEqual(rolesForUser1, ['editor']);
+      assert.deepStrictEqual(rolesForUser2, ['editor']);
+
+      // Verify database consistency by forcing a policy reload
+      await casbin.loadPolicy();
+      const usersAfterReload = await listUsers('editor');
+      assert.deepStrictEqual(usersAfterReload.sort(), [userId1, userId2]);
+    });
   });
 
   describe('updateOneById', () => {

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viron/lib",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "scripts": {
     "prebuild": "npm run clean",
     "build": "tsc --project tsconfig.json && cp -fr src/openapi dist/",

--- a/packages/nodejs/src/domains/adminrole.ts
+++ b/packages/nodejs/src/domains/adminrole.ts
@@ -182,7 +182,7 @@ export const listPolicies = async (
   const policies = roleId
     ? await casbin.getFilteredPolicy(0, roleId)
     : await casbin.getPolicy();
-  return policies.map((policy: unknown) => parsePolicy(policy as Policy));
+  return policies.map((policy) => parsePolicy(policy as Policy));
 };
 
 // 指定したロールを持つユーザーの一覧を取得
@@ -240,7 +240,7 @@ export const hasPermissionByResourceId = async (
   const casbin = repositoryContainer.getCasbin();
   await sync();
   const tasks = permissions.map((permission) =>
-    casbin.enforce(id, resourceId, permission).catch((e: unknown) => {
+    casbin.enforce(id, resourceId, permission).catch((e) => {
       debug(
         'Casbin Enforce failure. id: %s, resourceId: %s, permission: %s, error: %o',
         id,

--- a/packages/nodejs/src/domains/adminrole.ts
+++ b/packages/nodejs/src/domains/adminrole.ts
@@ -182,7 +182,7 @@ export const listPolicies = async (
   const policies = roleId
     ? await casbin.getFilteredPolicy(0, roleId)
     : await casbin.getPolicy();
-  return policies.map((policy) => parsePolicy(policy as Policy));
+  return policies.map((policy: unknown) => parsePolicy(policy as Policy));
 };
 
 // 指定したロールを持つユーザーの一覧を取得
@@ -240,7 +240,7 @@ export const hasPermissionByResourceId = async (
   const casbin = repositoryContainer.getCasbin();
   await sync();
   const tasks = permissions.map((permission) =>
-    casbin.enforce(id, resourceId, permission).catch((e) => {
+    casbin.enforce(id, resourceId, permission).catch((e: unknown) => {
       debug(
         'Casbin Enforce failure. id: %s, resourceId: %s, permission: %s, error: %o',
         id,

--- a/packages/nodejs/src/domains/adminrole.ts
+++ b/packages/nodejs/src/domains/adminrole.ts
@@ -218,7 +218,9 @@ export const updatePermissionsForRole = async (
     ({ resourceId, permission }): Policy =>
       genPolicy(roleId, resourceId, permission)
   );
-  await removeRole(roleId);
+  // removeRole（casbin.deleteRole）は g ルール（ユーザー・ロール割り当て）も
+  // DB から削除してしまうため、p ルール（ポリシー）のみ削除する
+  await casbin.removeFilteredPolicy(0, roleId);
   await Promise.all(policies.map((policy) => casbin.addPolicy(...policy)));
   return true;
 };


### PR DESCRIPTION
## 概要
updatePermissionsForRole() がロール権限の更新に removeRole() → casbin.deleteRole() を使用しており、casbin-mongoose-adapter の removeFilteredPolicy 実装が g タイプルールに対して $or クエリを使用し、v0 だけでなく v1 にもマッチするため、ユーザー・ロール割り当て（g, userId, roleId）もDBから削除される問題を修正しました。

## 根本原因
- casbin.deleteRole() は内部で removeFilteredGroupingPolicy(0, roleId) を呼び出す
- casbin-mongoose-adapter の removeFilteredPolicy は pType === 'g' の場合、$or: [{v0: roleId}, {v1: roleId}] クエリを生成
- これにより g, userId, roleId（v1 = roleId）も削除されてしまう
- Casbinのインメモリモデルは rule[0] === roleId のみチェックするため、DBと不整合が発生

## 修正内容
updatePermissionsForRole() で removeRole(roleId) の代わりに casbin.removeFilteredPolicy(0, roleId) を使用するように変更。
これにより p タイプルール（ポリシー）のみを削除し、g タイプルール（ユーザー・ロール割り当て）は保持します。

## 影響
- ロール権限更新時にユーザーのロール割り当てがDBから削除されなくなる
- DBとインメモリの不整合が解消される
- 次回のCasbin同期時にユーザーのロールが消失する問題が解消される

Fixes #894